### PR TITLE
Do not generate SELECT *

### DIFF
--- a/packages/soql-model/src/model/impl/queryImpl.test.ts
+++ b/packages/soql-model/src/model/impl/queryImpl.test.ts
@@ -38,7 +38,7 @@ describe('QueryImpl should', () => {
     expect(actual).toEqual(expected);
   });
   it('return query string, one line per clause with all but SELECT clause indented for toSoqlSyntax()', () => {
-    const expected = 'SELECT *\n' + '  FROM songs\n' + '  paint it black\n';
+    const expected = 'SELECT \n' + '  FROM songs\n' + '  paint it black\n';
     const actual = new Impl.QueryImpl(
       new Impl.SelectExprsImpl([]),
       new Impl.FromImpl('songs'),

--- a/packages/soql-model/src/model/impl/selectExprsImpl.test.ts
+++ b/packages/soql-model/src/model/impl/selectExprsImpl.test.ts
@@ -19,7 +19,7 @@ describe('SelectExprsImpl should', () => {
     expect(actual).toEqual(expected);
   });
   it('return SELECT * when there are no select expressions for toSoqlSyntax()', () => {
-    const expected = 'SELECT *';
+    const expected = 'SELECT ';
     const actual = new Impl.SelectExprsImpl([]).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });

--- a/packages/soql-model/src/model/impl/selectExprsImpl.ts
+++ b/packages/soql-model/src/model/impl/selectExprsImpl.ts
@@ -27,7 +27,7 @@ export class SelectExprsImpl extends SoqlModelObjectImpl
         first = false;
       });
     } else {
-      syntax += '*';
+      syntax += '';
     }
     return syntax;
   }


### PR DESCRIPTION
This PR changes the generated output for queries that have no selected fields. Previously `SELECT *` was generated but `SELECT *` is not a thing in SOQL so this was confusing. Now `SELECT` is generated with no fields.

@W-8048446@