### PR TITLE
use dispatch event instead of button click

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.test.ts
@@ -195,12 +195,10 @@ describe('App should', () => {
     expect(app.isFromLoading).toEqual(false);
   });
 
-  it('should send a runquery message when the user click Run Query button', async () => {
+  it('should send a runquery message to vs code with runquery event', async () => {
     const header = app.shadowRoot.querySelector('querybuilder-header');
-    const runBtn = header.shadowRoot.querySelector('button');
     const postMessageSpy = jest.spyOn(messageService, 'sendMessage');
-
-    runBtn.click();
+    header.dispatchEvent(new Event('runquery'));
 
     return Promise.resolve().then(() => {
       expect(postMessageSpy).toHaveBeenCalled();


### PR DESCRIPTION
This test would have falsely failed if another button was added to the header before the Run Query button. Having the header component dispatch an event is a more stable test pattern.