### PR TITLE
Reload sobjects on connection change

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/services/message/soqlEditorEvent.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/message/soqlEditorEvent.ts
@@ -8,7 +8,8 @@ export enum MessageType {
   SOBJECTS_REQUEST = 'sobjects_request',
   SOBJECTS_RESPONSE = 'sobjects_response',
   TEXT_SOQL_CHANGED = 'text_soql_changed',
-  RUN_SOQL_QUERY = 'run_query'
+  RUN_SOQL_QUERY = 'run_query',
+  CONNECTION_CHANGED = 'connection_changed'
 }
 
 export interface SoqlEditorEvent {

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/toolingSDK.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/toolingSDK.test.ts
@@ -29,6 +29,20 @@ describe('Tooling SDK Service', () => {
     vscode = getVscode();
   });
 
+  it('Load SObject metadata on CONNECTION_CHANGED message', () => {
+    // establish loaded SObject
+    toolingSDK.loadSObjectMetatada('Help!');
+
+    const loadDefsSpy = jest.spyOn(toolingSDK, 'loadSObjectDefinitions');
+    const loadObjSpy = jest.spyOn(toolingSDK, 'loadSObjectMetatada');
+
+    postMessageFromVSCode({ type: MessageType.CONNECTION_CHANGED });
+
+    expect(loadDefsSpy.mock.calls.length).toBe(1);
+    expect(loadObjSpy.mock.calls.length).toBe(1);
+    expect(loadObjSpy.mock.calls[0][0]).toBe('Help!');
+  });
+
   it('Retrieve SObjects', () => {
     jest.spyOn(vscode, 'postMessage');
     const sObjectsObserver = jest.fn();

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/toolingSDK.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/toolingSDK.ts
@@ -9,9 +9,11 @@
 import { IMessageService } from './message/iMessageService';
 import { MessageType, SoqlEditorEvent } from './message/soqlEditorEvent';
 import { BehaviorSubject, Observable } from 'rxjs';
+import { throwStatement } from '../../../../../../../../Library/Caches/typescript/4.0/node_modules/@babel/types/lib/index';
 
 export class ToolingSDK {
   private messageService: IMessageService;
+  private latestSObjectName?: string;
 
   public sobjects: Observable = new BehaviorSubject<string[]>([]);
   public sobjectMetadata: Observable = new BehaviorSubject<any>({ fields: [] });
@@ -32,6 +34,13 @@ export class ToolingSDK {
           this.sobjectMetadata.next(event.payload);
           break;
         }
+        case MessageType.CONNECTION_CHANGED: {
+          this.loadSObjectDefinitions();
+          if (this.latestSObjectName) {
+            this.loadSObjectMetatada(this.latestSObjectName);
+          }
+
+        }
         default:
           break;
       }
@@ -43,6 +52,7 @@ export class ToolingSDK {
   }
 
   loadSObjectMetatada(sobjectName: string) {
+    this.latestSObjectName = sobjectName;
     this.messageService.sendMessage({
       type: MessageType.SOBJECT_METADATA_REQUEST,
       payload: sobjectName


### PR DESCRIPTION
### What does this PR do?
This PR reacts to the `connection_changed` notification by reloading SObject metadata.

### What issues does this PR fix or reference?
@W-8207695@