### PR TITLE
Upsert order by field

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.ts
@@ -179,7 +179,7 @@ export default class App extends LightningElement {
   }
 
   handleOrderBySelected(e) {
-    this.modelService.addOrderByField(e.detail);
+    this.modelService.addUpdateOrderByField(e.detail);
   }
 
   handleOrderByRemoved(e) {

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.test.ts
@@ -141,7 +141,7 @@ describe('Tooling Model Service', () => {
     expect(query.unsupported.length).toEqual(0);
   });
 
-  it('should add, remove order by fields in model', () => {
+  it('should add, update, remove order by fields in model', () => {
     (messageService.setState as jest.Mock).mockClear();
     expect(messageService.setState).toHaveBeenCalledTimes(0);
     query = ToolingModelService.toolingModelTemplate;
@@ -149,21 +149,27 @@ describe('Tooling Model Service', () => {
     expect(query!.orderBy.length).toEqual(0);
 
     // Add
-    modelService.addOrderByField(mockOrderBy);
+    modelService.addUpdateOrderByField(mockOrderBy);
     expect(query!.orderBy.length).toBe(1);
     expect(query!.orderBy[0].field).toContain(mockOrderBy.field);
     expect(query!.orderBy[0].order).toContain(mockOrderBy.order);
     expect(query!.orderBy[0].nulls).toContain(mockOrderBy.nulls);
 
     // But Not Duplicate
-    modelService.addOrderByField(mockOrderBy);
+    modelService.addUpdateOrderByField(mockOrderBy);
     expect(query!.orderBy.length).toBe(1);
+
+    // Yet Update Field IF Direction and/or Nulls Change
+    expect(query!.orderBy[0].order).toBeDefined();
+    const updatedOrderBy = { field: 'orderBy1', order: undefined, nulls: 'NULLS LAST' };
+    modelService.addUpdateOrderByField(updatedOrderBy);
+    expect(query!.orderBy[0].order).not.toBeDefined();
 
     // Delete
     modelService.removeOrderByField(mockOrderBy.field);
     expect(query!.orderBy.length).toBe(0);
     // verify saves
-    expect(messageService.setState).toHaveBeenCalledTimes(2);
+    expect(messageService.setState).toHaveBeenCalledTimes(4);
   });
 
   it('should update limit in model', () => {
@@ -186,7 +192,7 @@ describe('Tooling Model Service', () => {
   });
 
   it('should add orderby as immutablejs', () => {
-    modelService.addOrderByField(mockOrderBy);
+    modelService.addUpdateOrderByField(mockOrderBy);
     const orderBy = modelService.getModel().get('orderBy');
     expect(typeof orderBy.toJS).toEqual('function');
   });

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.ts
@@ -113,19 +113,24 @@ export class ToolingModelService {
   }
 
   private hasOrderByField(field: string) {
-    return this.getOrderBy().some((item) => item.get('field') === field);
+    return this.getOrderBy().findIndex( (item) => item.get('field') === field );
   }
 
-  public addOrderByField(orderByObj: JsonMap) {
-    if (this.hasOrderByField(orderByObj.field) === false) {
-      const currentModel = this.getModel();
-      const newModelWithAddedField = currentModel.set(
-        'orderBy',
-        this.getOrderBy().push(fromJS(orderByObj))
-      ) as ToolingModel;
-
-      this.changeModel(newModelWithAddedField);
+  public addUpdateOrderByField(orderByObj: JsonMap) {
+    const currentModel = this.getModel();
+    let updatedOrderBy;
+    const existingIndex = this.hasOrderByField(orderByObj.field);
+    if (existingIndex > -1) {
+      updatedOrderBy = this.getOrderBy().update(existingIndex, () => { return fromJS(orderByObj)});
     }
+    else {
+      updatedOrderBy = this.getOrderBy().push(fromJS(orderByObj))
+    }
+    const newModel = currentModel.set(
+      'orderBy',
+      updatedOrderBy
+    ) as ToolingModel;
+    this.changeModel(newModel);
   }
 
   public removeOrderByField(field: string) {


### PR DESCRIPTION
### What does this PR do?
This PR adds update functionality to the ORDER BY field in the ui.  If the field already exists in the ORDER BY statement, then any additional properties ( order, nulls ) is updated on the existing ORDER BY statement.  This bug fix can be seen in the gif below.

![order-by-bugfix](https://user-images.githubusercontent.com/599418/97901664-b429ba00-1cf9-11eb-963b-6958ef7749b3.gif)


### What issues does this PR fix or reference?
@W-8252878@