### PR TITLE
publish language server 0.2.9

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/soql-language-server",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "SOQL Language Server",
   "engines": {
     "node": "*"


### PR DESCRIPTION
### What does this PR do?
This bumps the version of `@salesforce/soql-language-server` to 0.2.9 so it can be published in support of the VSCode build.

### What issues does this PR fix or reference?
@W-8431809@, @W-8432064@