### PR TITLE
Disabled 'Running...' button while query running

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.html
@@ -9,7 +9,7 @@
 <template>
   <main>
     <header class="querybuilder-header">
-      <querybuilder-header class={theme} onrunquery={handleRunQuery}></querybuilder-header>
+      <querybuilder-header class={theme} onrunquery={handleRunQuery} is-running={isQueryRunning}></querybuilder-header>
     </header>
     <article class="querybuilder-body">
       <section class="querybuilder-form">

--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.test.ts
@@ -17,7 +17,7 @@ import {
   MessageType,
   SoqlEditorEvent
 } from '../services/message/soqlEditorEvent';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { ArgumentOutOfRangeError, BehaviorSubject, Observable } from 'rxjs';
 import { MessageServiceFactory } from '../services/message/messageServiceFactory';
 import { IMessageService } from '../services/message/iMessageService';
 import { StandaloneMessageService } from '../services/message/standaloneMessageService';
@@ -27,9 +27,9 @@ class TestMessageService implements IMessageService {
   messagesToUI: Observable<SoqlEditorEvent> = new BehaviorSubject(
     ({} as unknown) as SoqlEditorEvent
   );
-  sendMessage() {}
-  setState() {}
-  getState() {}
+  sendMessage() { }
+  setState() { }
+  getState() { }
 }
 
 class TestApp extends App {
@@ -40,6 +40,8 @@ class TestApp extends App {
   isFromLoading = false;
   @api
   isFieldsLoading = false;
+  @api
+  isQueryRunning = false;
   @api
   hasUnrecoverableError = false;
 }
@@ -207,6 +209,14 @@ describe('App should', () => {
         type: MessageType.RUN_SOQL_QUERY
       });
     });
+  });
+
+  it('should clear isQueryRunning flag when run query returns', async () => {
+    app.isQueryRunning = true;
+    messageService.messagesToUI.next({
+      type: MessageType.RUN_SOQL_QUERY_DONE
+    });
+    expect(app.isQueryRunning).toEqual(false);
   });
 
   it('send orderby message to vs code when orderby added', () => {

--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.test.ts
@@ -17,7 +17,7 @@ import {
   MessageType,
   SoqlEditorEvent
 } from '../services/message/soqlEditorEvent';
-import { ArgumentOutOfRangeError, BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { MessageServiceFactory } from '../services/message/messageServiceFactory';
 import { IMessageService } from '../services/message/iMessageService';
 import { StandaloneMessageService } from '../services/message/standaloneMessageService';

--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.ts
@@ -59,6 +59,7 @@ export default class App extends LightningElement {
   hasUnrecoverableError = true;
   isFromLoading = false;
   isFieldsLoading = false;
+  isQueryRunning = false;
 
   @track
   query: ToolingModelJson = ToolingModelService.toolingModelTemplate;
@@ -90,6 +91,10 @@ export default class App extends LightningElement {
         sobjectMetadata && sobjectMetadata.fields
           ? sobjectMetadata.fields.map((f) => f.name)
           : [];
+    });
+
+    this.toolingSDK.queryRunState.subscribe((running: boolean) => {
+      this.isQueryRunning = false;
     });
     this.loadSObjectDefinitions();
     this.modelService.restoreViewState();
@@ -191,6 +196,7 @@ export default class App extends LightningElement {
   }
 
   handleRunQuery() {
+    this.isQueryRunning = true;
     const runQueryEvent: SoqlEditorEvent = { type: MessageType.RUN_SOQL_QUERY };
     this.messageService.sendMessage(runQueryEvent);
   }

--- a/packages/soql-builder-ui/src/modules/querybuilder/cssCommon/cssCommon.css
+++ b/packages/soql-builder-ui/src/modules/querybuilder/cssCommon/cssCommon.css
@@ -109,6 +109,14 @@ button:hover {
     var(--soql-color-blue-text)
   );
 }
+button:disabled {
+  color: var(--vscode-foreground, var(--soql-foreground));
+  background-color: var(
+    --vscode-list-inactiveSelectionBackground,
+    var(--soql-color-light-grey)
+  );
+  cursor: default;
+}
 .select-long {
   min-width: var(--soql-input-width);
   max-width: var(--soql-input-width);

--- a/packages/soql-builder-ui/src/modules/querybuilder/cssCommon/cssCommon.css
+++ b/packages/soql-builder-ui/src/modules/querybuilder/cssCommon/cssCommon.css
@@ -109,13 +109,13 @@ button:hover {
     var(--soql-color-blue-text)
   );
 }
-button:disabled {
-  color: var(--vscode-foreground, var(--soql-foreground));
+.btn--disabled {
   background-color: var(
     --vscode-list-inactiveSelectionBackground,
-    var(--soql-color-light-grey)
+    var(--soql-color-medium-grey)
   );
-  cursor: default;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 .select-long {
   min-width: var(--soql-input-width);

--- a/packages/soql-builder-ui/src/modules/querybuilder/header/header.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/header/header.html
@@ -13,7 +13,7 @@
         <button class="run-button" onclick={handleRunQuery}>Run Query</button>
       </template>
       <template if:true={isRunning}>
-        <button disabled>Running...</button>
+        <button class="btn--disabled">Running...</button>
       </template>
     </div>
   </header>

--- a/packages/soql-builder-ui/src/modules/querybuilder/header/header.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/header/header.html
@@ -10,7 +10,7 @@
   <header>
     <div class="container">
       <template if:false={isRunning}>
-        <button onclick={handleRunQuery}>Run Query</button>
+        <button class="run-button" onclick={handleRunQuery}>Run Query</button>
       </template>
       <template if:true={isRunning}>
         <button disabled>Running...</button>

--- a/packages/soql-builder-ui/src/modules/querybuilder/header/header.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/header/header.html
@@ -10,10 +10,10 @@
   <header>
     <div class="container">
       <template if:false={isRunning}>
-        <button class="run-button" onclick={handleRunQuery}>Run Query</button>
+        <button onclick={handleRunQuery}>Run Query</button>
       </template>
       <template if:true={isRunning}>
-        <button class="running-button" disabled>Running...</button>
+        <button disabled>Running...</button>
       </template>
     </div>
   </header>

--- a/packages/soql-builder-ui/src/modules/querybuilder/header/header.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/header/header.html
@@ -8,6 +8,13 @@
 
 <template>
   <header>
-    <button class="run-button" onclick={handleRunQuery}>Run Query</button>
+    <div class="container">
+      <template if:false={isRunning}>
+        <button class="run-button" onclick={handleRunQuery}>Run Query</button>
+      </template>
+      <template if:true={isRunning}>
+        <button class="running-button" disabled>Running...</button>
+      </template>
+    </div>
   </header>
 </template>

--- a/packages/soql-builder-ui/src/modules/querybuilder/header/header.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/header/header.ts
@@ -6,8 +6,10 @@
  *
  */
 
-import { LightningElement } from 'lwc';
+import { LightningElement, api } from 'lwc';
 export default class Header extends LightningElement {
+  @api isRunning = false;
+
   handleRunQuery(e: Event) {
     e.preventDefault();
     const runEvent = new CustomEvent('runquery');

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/message/soqlEditorEvent.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/message/soqlEditorEvent.ts
@@ -9,7 +9,8 @@ export enum MessageType {
   SOBJECTS_RESPONSE = 'sobjects_response',
   TEXT_SOQL_CHANGED = 'text_soql_changed',
   RUN_SOQL_QUERY = 'run_query',
-  CONNECTION_CHANGED = 'connection_changed'
+  CONNECTION_CHANGED = 'connection_changed',
+  RUN_SOQL_QUERY_DONE = 'run_query_done'
 }
 
 export interface SoqlEditorEvent {

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/message/standaloneMessageService.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/message/standaloneMessageService.ts
@@ -18,17 +18,6 @@ class MockVscode {
   private localStorage = getLocalStorage();
   postMessage(messageObj) {
     this.window.parent.postMessage(messageObj, '*');
-    if (messageObj.type === MessageType.RUN_SOQL_QUERY) {
-      // send run_query_done after 3 seconds for standalone
-      setTimeout(function () {
-        this.window.postMessage(
-          { type: MessageType.RUN_SOQL_QUERY_DONE },
-          '*'
-        );
-      },
-        3000
-      );
-    }
   }
   public getState(): JsonMap {
     let state = this.localStorage.getItem('query');

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/message/standaloneMessageService.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/message/standaloneMessageService.ts
@@ -18,6 +18,17 @@ class MockVscode {
   private localStorage = getLocalStorage();
   postMessage(messageObj) {
     this.window.parent.postMessage(messageObj, '*');
+    if (messageObj.type === MessageType.RUN_SOQL_QUERY) {
+      // send run_query_done after 3 seconds for standalone
+      setTimeout(function () {
+        this.window.postMessage(
+          { type: MessageType.RUN_SOQL_QUERY_DONE },
+          '*'
+        );
+      },
+        3000
+      );
+    }
   }
   public getState(): JsonMap {
     let state = this.localStorage.getItem('query');

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/toolingSDK.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/toolingSDK.test.ts
@@ -100,4 +100,13 @@ describe('Tooling SDK Service', () => {
       fakeSObjectMetadata
     );
   });
+
+  it('Receive run_query_done message', () => {
+    const runStateObserver = jest.fn();
+    toolingSDK.queryRunState.subscribe(runStateObserver);
+    postMessageFromVSCode({
+      type: MessageType.RUN_SOQL_QUERY_DONE
+    });
+    expect(runStateObserver.mock.calls.length).toBe(2);
+  });
 });

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/toolingSDK.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/toolingSDK.ts
@@ -9,7 +9,6 @@
 import { IMessageService } from './message/iMessageService';
 import { MessageType, SoqlEditorEvent } from './message/soqlEditorEvent';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { throwStatement } from '../../../../../../../../Library/Caches/typescript/4.0/node_modules/@babel/types/lib/index';
 
 export class ToolingSDK {
   private messageService: IMessageService;
@@ -17,6 +16,7 @@ export class ToolingSDK {
 
   public sobjects: Observable = new BehaviorSubject<string[]>([]);
   public sobjectMetadata: Observable = new BehaviorSubject<any>({ fields: [] });
+  public queryRunState: Observable = new BehaviorSubject<boolean>(false);
 
   constructor(messageService: IMessageService) {
     this.messageService = messageService;
@@ -39,7 +39,9 @@ export class ToolingSDK {
           if (this.latestSObjectName) {
             this.loadSObjectMetatada(this.latestSObjectName);
           }
-
+        }
+        case MessageType.RUN_SOQL_QUERY_DONE: {
+          this.queryRunState.next(false);
         }
         default:
           break;


### PR DESCRIPTION
### What does this PR do?
This PR provides the SOQL Builder UI-side function for indication that a query is running. When the `Run Query` button is pressed, the button is transformed into a disabled `Running...` button, and remains so until VSCode sends the `run_query_done` message.
![runquery](https://user-images.githubusercontent.com/55159130/102395065-a5951a80-3fa8-11eb-8b59-8e73e86c4f36.gif)


### What issues does this PR fix or reference?
@W-8207738@