### PR TITLE
Add basic code-completion for ORDER BY and other improvements

### DIFF
--- a/packages/language-server/src/completion.test.ts
+++ b/packages/language-server/src/completion.test.ts
@@ -278,10 +278,7 @@ describe('Some keyword candidates after FROM clause', () => {
     )
   );
 
-  validateCompletionsFor(
-    'SELECT id FROM Account LIMIT |',
-    expectItems(CompletionItemKind.Constant, '0', '1', '5', '10', '25', '100')
-  );
+  validateCompletionsFor('SELECT id FROM Account LIMIT |', []);
 });
 
 function expectKeywords(...words: string[]): CompletionItem[] {

--- a/packages/language-server/src/completion.test.ts
+++ b/packages/language-server/src/completion.test.ts
@@ -130,17 +130,9 @@ describe('Code Completion on nested select fields: SELECT ... FROM XYZ', () => {
 
 // describe.only('ONLY', () => {
 //   validateCompletionsFor(
-//     'SELECT (SELECT ), | FROM Foo',
-//     sobjectsFieldsFor('Foo')
+//     'SELECT (SELECT |) FROM Foo',
+//     sobjectsFieldsFor('Object')
 //   );
-// validateCompletionsFor(
-//   'SELECT | (SELECT bar FROM Bar) FROM Foo',
-//   sobjectsFieldsFor('Foo')
-// );
-// validateCompletionsFor(
-//   'SELECT (SELECT |) FROM Foo',
-//   sobjectsFieldsFor('Object')
-// );
 // });
 
 describe('Code Completion on SELECT XYZ FROM...', () => {
@@ -242,6 +234,11 @@ describe('Some keyword candidates after FROM clause', () => {
   );
 
   validateCompletionsFor(
+    'SELECT id FROM Account WITH |',
+    expectKeywords('DATA CATEGORY')
+  );
+
+  validateCompletionsFor(
     'SELECT Account.Name, (SELECT FirstName, LastName FROM Contacts |) FROM Account',
     expectKeywords(
       'FOR',
@@ -254,7 +251,7 @@ describe('Some keyword candidates after FROM clause', () => {
       'UPDATE TRACKING',
       'UPDATE VIEWSTAT'
     ),
-    true
+    { skip: true }
   );
 });
 
@@ -269,10 +266,10 @@ function expectKeywords(...words: string[]): CompletionItem[] {
 function validateCompletionsFor(
   text: string,
   expectedItems: CompletionItem[],
-  skip: boolean = false,
-  cursorChar: string = '|'
+  options: { skip?: boolean; only?: boolean; cursorChar?: string } = {}
 ) {
-  const itFn = skip ? xit : it;
+  const itFn = options.skip ? xit : options.only ? it.only : it;
+  const cursorChar = options.cursorChar || '|';
   itFn(text, () => {
     if (text.indexOf(cursorChar) != text.lastIndexOf(cursorChar)) {
       throw new Error(

--- a/packages/language-server/src/completion.test.ts
+++ b/packages/language-server/src/completion.test.ts
@@ -126,14 +126,28 @@ describe('Code Completion on nested select fields: SELECT ... FROM XYZ', () => {
     'SELECT foo, (|) FROM Foo',
     expectKeywords('SELECT').concat(SELECT_snippet)
   );
-});
 
-// describe.only('ONLY', () => {
-//   validateCompletionsFor(
-//     'SELECT (SELECT |) FROM Foo',
-//     sobjectsFieldsFor('Object')
-//   );
-// });
+  validateCompletionsFor(
+    'SELECT foo, (SELECT bar FROM Bar), (SELECT | FROM Xyz) FROM Foo',
+    sobjectsFieldsFor('Xyz')
+  );
+  validateCompletionsFor(
+    'SELECT foo, (SELECT bar FROM Bar), (SELECT xyz, | FROM Xyz) FROM Foo',
+    sobjectsFieldsFor('Xyz')
+  );
+  validateCompletionsFor(
+    'SELECT foo, | (SELECT bar FROM Bar), (SELECT xyz FROM Xyz) FROM Foo',
+    sobjectsFieldsFor('Foo')
+  );
+  validateCompletionsFor(
+    'SELECT foo, (SELECT bar FROM Bar), | (SELECT xyz FROM Xyz) FROM Foo',
+    sobjectsFieldsFor('Foo')
+  );
+  validateCompletionsFor(
+    'SELECT foo, (SELECT | FROM Bar), (SELECT xyz FROM Xyz) FROM Foo',
+    sobjectsFieldsFor('Bar')
+  );
+});
 
 describe('Code Completion on SELECT XYZ FROM...', () => {
   validateCompletionsFor('SELECT id FROM |', expectedSObjectCompletions);

--- a/packages/language-server/src/completion.ts
+++ b/packages/language-server/src/completion.ts
@@ -110,7 +110,6 @@ function collectC3CompletionCandidates(
     SoqlParser.RULE_soqlFromExpr,
     SoqlParser.RULE_soqlField,
     SoqlParser.RULE_soqlUpdateStatsClause,
-    SoqlParser.RULE_soqlInteger,
     SoqlParser.RULE_parseReservedForFieldName, // <-- We list it here so that C3 ignores tokens of that rule
   ]);
 
@@ -243,16 +242,6 @@ function generateCandidatesFromRules(
               newSnippetItem('(SELECT ... FROM ...)', '(SELECT $2 FROM $1)')
             );
           }
-        }
-        break;
-      case SoqlParser.RULE_soqlInteger:
-        if (isCursorAfter(tokenStream, tokenIndex, [SoqlLexer.LIMIT])) {
-          completionItems.push(newNumberItem('0'));
-          completionItems.push(newNumberItem('1'));
-          completionItems.push(newNumberItem('5'));
-          completionItems.push(newNumberItem('10'));
-          completionItems.push(newNumberItem('25'));
-          completionItems.push(newNumberItem('100'));
         }
         break;
     }

--- a/packages/language-server/src/completion.ts
+++ b/packages/language-server/src/completion.ts
@@ -1,14 +1,8 @@
 import {
-  SoqlFromClauseContext,
-  SoqlFromExprsContext,
-  SoqlInnerQueryContext,
   SoqlParser,
   SoqlQueryContext,
-  SoqlSelectClauseContext,
-  SoqlSelectInnerQueryExprContext,
 } from '@salesforce/soql-parser/lib/generated/SoqlParser';
 import { SoqlLexer } from '@salesforce/soql-parser/lib/generated/SoqlLexer';
-import { SoqlParserListener } from '@salesforce/soql-parser/lib/generated/SoqlParserListener';
 import { LowerCasingCharStream } from '@salesforce/soql-parser';
 import {
   CompletionItem,
@@ -16,23 +10,12 @@ import {
   InsertTextFormat,
 } from 'vscode-languageserver';
 
-import {
-  CommonTokenStream,
-  DefaultErrorStrategy,
-  ParserRuleContext,
-  Token,
-  TokenStream,
-} from 'antlr4ts';
-import {
-  ParseTreeWalker,
-  ParseTreeListener,
-  ErrorNode,
-  RuleNode,
-} from 'antlr4ts/tree';
+import { CommonTokenStream, Parser, TokenStream } from 'antlr4ts';
 
 import * as c3 from 'antlr4-c3';
 import { format } from 'util';
 import { SoqlCompletionErrorStrategy } from './completion/SoqlCompletionErrorStrategy';
+import { SoqlQueryExtractor } from './completion/SoqlQueryExtractor';
 
 const SOBJECTS_ITEM_LABEL_PLACEHOLDER = '__SOBJECTS_PLACEHOLDER';
 const SOBJECT_FIELDS_LABEL_PLACEHOLDER = '__SOBJECT_FIELDS_PLACEHOLDER:%s';
@@ -49,6 +32,45 @@ export function completionsFor(
   parser.errorHandler = new SoqlCompletionErrorStrategy();
 
   const parsedQuery = parser.soqlQuery();
+  const core = createC3CompletionEngine(parser);
+  const completionTokenIndex = findCursorTokenIndex(tokenStream, {
+    line,
+    column: column,
+  });
+
+  if (completionTokenIndex === undefined) {
+    console.error(
+      "Couldn't find cursor position on toke stream! Lexer might be skipping some tokens!"
+    );
+    return [];
+  }
+
+  const c3Candidates = core.collectCandidates(
+    completionTokenIndex,
+    parsedQuery
+  );
+  const itemsFromTokens: CompletionItem[] = generateCandidatesFromTokens(
+    c3Candidates.tokens,
+    lexer
+  );
+  const itemsFromRules: CompletionItem[] = generateCandidatesFromRules(
+    c3Candidates.rules,
+    parsedQuery,
+    tokenStream,
+    completionTokenIndex
+  );
+
+  const completionItems = itemsFromTokens.concat(itemsFromRules);
+
+  // If we got no proposals from C3, handle some special cases "manually"
+  if (completionItems.length == 0) {
+    return handleSpecialCases(parsedQuery, tokenStream, completionTokenIndex);
+  }
+
+  return completionItems;
+}
+
+function createC3CompletionEngine(parser: Parser) {
   const core = new c3.CodeCompletionCore(parser);
   core.translateRulesTopDown = true;
   core.ignoredTokens = new Set([
@@ -58,6 +80,7 @@ export function completionsFor(
     SoqlLexer.PLUS,
     SoqlLexer.MINUS,
   ]);
+
   core.preferredRules = new Set([
     SoqlParser.RULE_soqlFromExprs,
     SoqlParser.RULE_soqlFromExpr,
@@ -67,25 +90,97 @@ export function completionsFor(
     SoqlParser.RULE_soqlInteger,
     SoqlParser.RULE_parseReservedForFieldName, // <-- We list it here so that C3 ignores tokens of that rule
   ]);
-  const tokenIndex = findCursorTokenIndex(tokenStream, {
-    line,
-    column: column,
-  });
+  return core;
+}
+const possibleIdentifierPrefix = /[\w]$/;
+export type CursorPosition = { line: number; column: number };
+/**
+  Return the token index for which we want to provide completion candidates,
+  which depends on the cursor possition.
 
-  if (tokenIndex === undefined) {
-    console.error(
-      "Couldn't find cursor position on toke stream! Lexer might be skipping some tokens!"
-    );
-    return [];
+  Examples:
+
+  SELECT id| FROM x     : Cursor touching the previous identifier token:
+                          we want to continue completing that prior token position
+  SELECT id |FROM x     : Cursor NOT touching the previous identifier token:
+                          we want to complete what comes on this new position
+  SELECT id   |  FROM x : Cursor within whitespace block: we want to complete what
+                          comes after the whitespace (we must return a non-WS token index)
+*/
+export function findCursorTokenIndex(
+  tokenStream: TokenStream,
+  cursor: CursorPosition
+) {
+  // NOTE: cursor position is 1-based, while token's charPositionInLine is 0-based
+  const cursorCol = cursor.column - 1;
+  for (let i = 0; i < tokenStream.size; i++) {
+    const t = tokenStream.get(i);
+
+    if (t.line > cursor.line) {
+      return i;
+    }
+
+    let tokenStartCol = t.charPositionInLine;
+    let tokenEndCol = tokenStartCol + (t.text as string).length;
+
+    if (
+      t.line == cursor.line &&
+      (tokenEndCol > cursorCol || t.type === SoqlLexer.EOF)
+    ) {
+      if (
+        i > 0 &&
+        tokenStartCol === cursorCol &&
+        possibleIdentifierPrefix.test(tokenStream.get(i - 1).text as string)
+      ) {
+        return i - 1;
+      } else if (tokenStream.get(i).type === SoqlLexer.WS) {
+        return i + 1;
+      } else return i;
+    }
   }
+}
 
-  const candidatesFromGrammar = core.collectCandidates(tokenIndex, parsedQuery);
-  const completionItems: CompletionItem[] = generateCandidatesFromTokens(
-    candidatesFromGrammar.tokens,
-    lexer
-  );
+function tokenTypeToCandidateString(
+  lexer: SoqlLexer,
+  tokenType: number
+): string {
+  return lexer.vocabulary
+    .getLiteralName(tokenType)
+    ?.toUpperCase()
+    .replace(/^'|'$/g, '') as string;
+}
+function generateCandidatesFromTokens(
+  tokens: Map<number, c3.TokenList>,
+  lexer: SoqlLexer
+): CompletionItem[] {
+  const items: CompletionItem[] = [];
+  for (let [tokenType, followingTokens] of tokens) {
+    const baseKeyword = tokenTypeToCandidateString(lexer, tokenType);
+    if (!baseKeyword) continue;
+    const followingKeywords = followingTokens
+      .map((t) => tokenTypeToCandidateString(lexer, t))
+      .join(' ');
 
-  for (let [ruleId, ruleData] of candidatesFromGrammar.rules) {
+    items.push(
+      newKeywordItem(
+        followingKeywords.length > 0
+          ? baseKeyword + ' ' + followingKeywords
+          : baseKeyword
+      )
+    );
+  }
+  return items;
+}
+
+function generateCandidatesFromRules(
+  c3Rules: Map<number, c3.CandidateRule>,
+  parsedQuery: SoqlQueryContext,
+  tokenStream: TokenStream,
+  tokenIndex: number
+): CompletionItem[] {
+  const completionItems: CompletionItem[] = [];
+
+  for (let [ruleId, ruleData] of c3Rules) {
     switch (ruleId) {
       case SoqlParser.RULE_soqlSelectClause:
         if (tokenIndex <= ruleData.startTokenIndex) {
@@ -147,145 +242,34 @@ export function completionsFor(
         break;
     }
   }
+  return completionItems;
+}
+function handleSpecialCases(
+  parsedQuery: SoqlQueryContext,
+  tokenStream: TokenStream,
+  tokenIndex: number
+): CompletionItem[] {
+  const completionItems: CompletionItem[] = [];
 
-  // If we got no proposals from C3, handle some special cases "manually"
-  if (completionItems.length == 0) {
-    if (
-      isCursorAfter(tokenStream, tokenIndex, [SoqlLexer.SELECT, SoqlLexer.FROM])
-    ) {
-      completionItems.push(newObjectItem(SOBJECTS_ITEM_LABEL_PLACEHOLDER));
-    } else if (
-      isCursorAfter(tokenStream, tokenIndex, [SoqlLexer.COMMA]) &&
-      isCursorBefore(tokenStream, tokenIndex, [SoqlLexer.FROM])
-    ) {
-      const fromSObject =
-        SoqlQueryExtractor.getSObjectFor(parsedQuery, tokenIndex) || 'Object';
-      completionItems.push(
-        newFieldItem(format(SOBJECT_FIELDS_LABEL_PLACEHOLDER, fromSObject))
-      );
-      completionItems.push(
-        newSnippetItem('(SELECT ... FROM ...)', '(SELECT $2 FROM $1)')
-      );
-    }
+  if (
+    isCursorAfter(tokenStream, tokenIndex, [SoqlLexer.SELECT, SoqlLexer.FROM])
+  ) {
+    completionItems.push(newObjectItem(SOBJECTS_ITEM_LABEL_PLACEHOLDER));
+  } else if (
+    isCursorAfter(tokenStream, tokenIndex, [SoqlLexer.COMMA]) &&
+    isCursorBefore(tokenStream, tokenIndex, [SoqlLexer.FROM])
+  ) {
+    const fromSObject =
+      SoqlQueryExtractor.getSObjectFor(parsedQuery, tokenIndex) || 'Object';
+    completionItems.push(
+      newFieldItem(format(SOBJECT_FIELDS_LABEL_PLACEHOLDER, fromSObject))
+    );
+    completionItems.push(
+      newSnippetItem('(SELECT ... FROM ...)', '(SELECT $2 FROM $1)')
+    );
   }
 
   return completionItems;
-}
-
-const possibleIdentifierPrefix = /[\w]$/;
-export type CursorPosition = { line: number; column: number };
-/**
-  Return the token index for which we want to provide completion candidates,
-  which depends on the cursor possition.
-
-  Examples:
-
-  SELECT id| FROM x     : Cursor touching the previous identifier token:
-                          we want to continue completing that prior token position
-  SELECT id |FROM x     : Cursor NOT touching the previous identifier token:
-                          we want to complete what comes on this new position
-  SELECT id   |  FROM x : Cursor within whitespace block: we want to complete what
-                          comes after the whitespace (we must return a non-WS token index)
-*/
-export function findCursorTokenIndex(
-  tokenStream: TokenStream,
-  cursor: CursorPosition
-) {
-  // NOTE: cursor position is 1-based, while token's charPositionInLine is 0-based
-  const cursorCol = cursor.column - 1;
-  for (let i = 0; i < tokenStream.size; i++) {
-    const t = tokenStream.get(i);
-
-    if (t.line > cursor.line) {
-      return i;
-    }
-
-    let tokenStartCol = t.charPositionInLine;
-    let tokenEndCol = tokenStartCol + (t.text as string).length;
-
-    if (
-      t.line == cursor.line &&
-      (tokenEndCol > cursorCol || t.type === SoqlLexer.EOF)
-    ) {
-      if (
-        i > 0 &&
-        tokenStartCol === cursorCol &&
-        possibleIdentifierPrefix.test(tokenStream.get(i - 1).text as string)
-      ) {
-        return i - 1;
-      } else if (tokenStream.get(i).type === SoqlLexer.WS) {
-        return i + 1;
-      } else return i;
-    }
-  }
-}
-
-function newKeywordItem(text: string): CompletionItem {
-  return {
-    label: text,
-    kind: CompletionItemKind.Keyword,
-    insertText: text + ' ',
-  };
-}
-function newFieldItem(text: string): CompletionItem {
-  return {
-    label: text,
-    kind: CompletionItemKind.Field,
-  };
-}
-
-function newNumberItem(text: string): CompletionItem {
-  return {
-    label: text,
-    kind: CompletionItemKind.Constant,
-  };
-}
-function newObjectItem(text: string): CompletionItem {
-  return {
-    label: text,
-    kind: CompletionItemKind.Class,
-  };
-}
-
-function newSnippetItem(label: string, snippet: string): CompletionItem {
-  return {
-    label: label,
-    kind: CompletionItemKind.Snippet,
-    insertText: snippet,
-    insertTextFormat: InsertTextFormat.Snippet,
-  };
-}
-
-function tokenTypeToCandidateString(
-  lexer: SoqlLexer,
-  tokenType: number
-): string {
-  return lexer.vocabulary
-    .getLiteralName(tokenType)
-    ?.toUpperCase()
-    .replace(/^'|'$/g, '') as string;
-}
-function generateCandidatesFromTokens(
-  tokens: Map<number, c3.TokenList>,
-  lexer: SoqlLexer
-): CompletionItem[] {
-  const items: CompletionItem[] = [];
-  for (let [tokenType, followingTokens] of tokens) {
-    const baseKeyword = tokenTypeToCandidateString(lexer, tokenType);
-    if (!baseKeyword) continue;
-    const followingKeywords = followingTokens
-      .map((t) => tokenTypeToCandidateString(lexer, t))
-      .join(' ');
-
-    items.push(
-      newKeywordItem(
-        followingKeywords.length > 0
-          ? baseKeyword + ' ' + followingKeywords
-          : baseKeyword
-      )
-    );
-  }
-  return items;
 }
 
 function isCursorAfter(
@@ -324,209 +308,39 @@ function isCursorBefore(
   }
   return false;
 }
-/***********
 
-interface SelectFromPair {
-  select: Token;
-  from: Token;
-  sobjectName: string;
+function newKeywordItem(text: string): CompletionItem {
+  return {
+    label: text,
+    kind: CompletionItemKind.Keyword,
+    insertText: text + ' ',
+  };
+}
+function newFieldItem(text: string): CompletionItem {
+  return {
+    label: text,
+    kind: CompletionItemKind.Field,
+  };
 }
 
-class FromExpressionExtractor implements SoqlParserListener {
-  sobjectName?: string;
-  closestStartIndex = -1;
-
-  selectsStack: Token[] = [];
-
-  matchedSelectFroms: Array<SelectFromPair> = [];
-
-  constructor(private cursorTokenIndex: number) {}
-
-  static getSObjectFor(
-    parsedQueryTree: SoqlQueryContext,
-    cursorTokenIndex: number
-  ): string | undefined {
-    const listener = new FromExpressionExtractor(cursorTokenIndex);
-    ParseTreeWalker.DEFAULT.walk<SoqlParserListener>(listener, parsedQueryTree);
-    return listener.findSObjectName(cursorTokenIndex);
-  }
-
-  private isInside(pair: SelectFromPair, index: number): boolean {
-    return pair.select.tokenIndex <= index && pair?.from.tokenIndex >= index;
-  }
-  public findSObjectName(index: number): string | undefined {
-    let closest;
-
-    for (let pair of this.matchedSelectFroms) {
-      if (
-        this.isInside(pair, index) &&
-        (!closest ||
-          index - pair.select.tokenIndex < index - closest.select.tokenIndex)
-      ) {
-        closest = pair;
-      }
-    }
-    return closest?.sobjectName;
-  }
-  private foundMatch(fromToken: Token, sobjectName: string) {
-    const selectToken = this.selectsStack.pop();
-    if (selectToken) {
-      this.matchedSelectFroms.push({
-        select: selectToken,
-        from: fromToken,
-        sobjectName: sobjectName,
-      });
-    }
-  }
-
-  visitErrorNode(node: ErrorNode) {
-    if (
-      node.symbol.type === SoqlLexer.FROM &&
-      node.parent &&
-      // node.parent.ruleIndex === SoqlParser.RULE_soqlSelectExpr &&
-      node.parent.childCount >= 2
-    ) {
-      const fromToken = node.symbol;
-      const sobjectName = node.parent.getChild(1).text;
-      this.foundMatch(fromToken, sobjectName);
-    }
-  }
-  enterSoqlInnerQuery(ctx: SoqlInnerQueryContext) {
-    this.selectsStack.push(ctx.start);
-  }
-  exitSoqlFromExprs(ctx: SoqlFromExprsContext) {
-    if (ctx.children && ctx.children.length > 0) {
-      const fromToken = ctx.parent?.start as Token;
-      const sobjectName = ctx.getChild(0).getChild(0).text;
-      this.foundMatch(fromToken, sobjectName);
-    }
-  }
+function newNumberItem(text: string): CompletionItem {
+  return {
+    label: text,
+    kind: CompletionItemKind.Constant,
+  };
+}
+function newObjectItem(text: string): CompletionItem {
+  return {
+    label: text,
+    kind: CompletionItemKind.Class,
+  };
 }
 
-*******/
-
-interface InnerSoqlQuery {
-  soqlInnerQueryNode: SoqlInnerQueryContext;
-  select: Token;
-  from?: Token;
-  sobjectName?: string;
-}
-class SoqlQueryExtractor implements SoqlParserListener {
-  selectsStack: Token[] = [];
-  fromsStack: Array<[Token, string]> = [];
-
-  matchedSelectFroms: Array<InnerSoqlQuery> = [];
-
-  innerSoqlQueries = new Map<number, InnerSoqlQuery>();
-
-  constructor(private cursorTokenIndex: number) {}
-
-  static getSObjectFor(
-    parsedQueryTree: SoqlQueryContext,
-    cursorTokenIndex: number
-  ): string | undefined {
-    const listener = new SoqlQueryExtractor(cursorTokenIndex);
-    ParseTreeWalker.DEFAULT.walk<SoqlParserListener>(listener, parsedQueryTree);
-    return listener.findInnerQuery(cursorTokenIndex)?.sobjectName;
-  }
-  private queryContainsTokenIndex(
-    innerQuery: InnerSoqlQuery,
-    atTokenIndex: number
-  ): boolean {
-    // NOTE: We use the parent node to take into account the enclosing
-    // parentheses (in the case of inner SELECTs), and the whole text until EOF
-    // (for the top-level SELECT). BTW: soqlInnerQueryNode always has a parent.
-    const queryNode = innerQuery.soqlInnerQueryNode.parent
-      ? innerQuery.soqlInnerQueryNode.parent
-      : innerQuery.soqlInnerQueryNode;
-
-    const startIndex = queryNode.start.tokenIndex;
-    const stopIndex = queryNode.stop?.tokenIndex;
-
-    return (
-      atTokenIndex > startIndex && !!stopIndex && atTokenIndex <= stopIndex
-    );
-  }
-
-  private findInnerQuery(atIndex: number): InnerSoqlQuery | undefined {
-    let closestQuery: InnerSoqlQuery | undefined;
-    for (let query of this.innerSoqlQueries.values()) {
-      if (this.queryContainsTokenIndex(query, atIndex)) {
-        closestQuery = query;
-      }
-    }
-    return closestQuery;
-  }
-
-  private findSoqlInnerQueryAncestor(
-    node: RuleNode | undefined
-  ): SoqlInnerQueryContext | undefined {
-    let soqlInnerQueryNode = node;
-    while (
-      soqlInnerQueryNode &&
-      soqlInnerQueryNode.ruleContext.ruleIndex !==
-        SoqlParser.RULE_soqlInnerQuery
-    ) {
-      soqlInnerQueryNode = soqlInnerQueryNode.parent;
-    }
-
-    return soqlInnerQueryNode
-      ? (soqlInnerQueryNode as SoqlInnerQueryContext)
-      : undefined;
-  }
-
-  visitErrorNode(node: ErrorNode) {
-    if (node.parent) {
-      const parentRule = node.parent?.ruleContext.ruleIndex;
-
-      if (
-        parentRule === SoqlParser.RULE_soqlSelectExpr &&
-        node.symbol.type === SoqlLexer.FROM &&
-        node.parent &&
-        node.parent.childCount >= 2
-      ) {
-        const fromToken = node.symbol;
-        const sobjectName = node.parent.getChild(1).text;
-
-        const soqlInnerQueryNode = this.findSoqlInnerQueryAncestor(node.parent);
-        if (soqlInnerQueryNode) {
-          const innerQuery = this.innerSoqlQueries.get(
-            (soqlInnerQueryNode as SoqlInnerQueryContext).start.tokenIndex
-          );
-          if (innerQuery) {
-            innerQuery.from = fromToken;
-            innerQuery.sobjectName = sobjectName;
-          }
-        }
-        // } else if (parentRule === SoqlParser.RULE_soqlSelectClause) {
-        // }
-      }
-    }
-  }
-
-  enterSoqlInnerQuery(ctx: SoqlInnerQueryContext) {
-    this.innerSoqlQueries.set(ctx.start.tokenIndex, {
-      select: ctx.start,
-      soqlInnerQueryNode: ctx,
-    });
-  }
-
-  exitSoqlFromExprs(ctx: SoqlFromExprsContext) {
-    const soqlInnerQueryNode = this.findSoqlInnerQueryAncestor(ctx);
-
-    if (ctx.children && ctx.children.length > 0 && soqlInnerQueryNode) {
-      const fromToken = ctx.parent?.start as Token;
-      const sobjectName = ctx.getChild(0).getChild(0).text;
-      const selectFromPair = this.innerSoqlQueries.get(
-        soqlInnerQueryNode.start.tokenIndex
-      );
-      if (selectFromPair) {
-        selectFromPair.from = fromToken;
-        selectFromPair.sobjectName = sobjectName;
-      }
-    }
-  }
-
-  // exitSoqlInnerQuery(ctx: SoqlInnerQueryContext) {
-  // }
+function newSnippetItem(label: string, snippet: string): CompletionItem {
+  return {
+    label: label,
+    kind: CompletionItemKind.Snippet,
+    insertText: snippet,
+    insertTextFormat: InsertTextFormat.Snippet,
+  };
 }

--- a/packages/language-server/src/completion/SoqlCompletionErrorStrategy.ts
+++ b/packages/language-server/src/completion/SoqlCompletionErrorStrategy.ts
@@ -4,6 +4,16 @@ import { Token } from 'antlr4ts/Token';
 
 export class SoqlCompletionErrorStrategy extends DefaultErrorStrategy {
   protected singleTokenDeletion(recognizer: Parser): Token | undefined {
+    // The default error handling strategy is "too smart" for our code-completion purposes.
+    // We generally do NOT want the parser to remove tokens for recovery.
+    //
+    // Example:
+    //    SELECT id, | FROM Foo
+    //
+    // Here the parser drops `FROM` and makes Foo a field on SELECTs' list
+    // So we don't recognize Foo as the SObject we want to query for.
+    //
+    // We might implement more SOQL-specific logic in the future.
     return undefined;
   }
 }

--- a/packages/language-server/src/completion/SoqlCompletionErrorStrategy.ts
+++ b/packages/language-server/src/completion/SoqlCompletionErrorStrategy.ts
@@ -1,0 +1,9 @@
+import { DefaultErrorStrategy } from 'antlr4ts/DefaultErrorStrategy';
+import { Parser } from 'antlr4ts/Parser';
+import { Token } from 'antlr4ts/Token';
+
+export class SoqlCompletionErrorStrategy extends DefaultErrorStrategy {
+  protected singleTokenDeletion(recognizer: Parser): Token | undefined {
+    return undefined;
+  }
+}

--- a/packages/language-server/src/completion/SoqlCompletionErrorStrategy.ts
+++ b/packages/language-server/src/completion/SoqlCompletionErrorStrategy.ts
@@ -3,17 +3,21 @@ import { Parser } from 'antlr4ts/Parser';
 import { Token } from 'antlr4ts/Token';
 
 export class SoqlCompletionErrorStrategy extends DefaultErrorStrategy {
+  /**
+   * The default error handling strategy is "too smart" for our code-completion purposes.
+   * We generally do NOT want the parser to remove tokens for recovery.
+   *
+   * @example
+   * ```soql
+   *    SELECT id, | FROM Foo
+   * ```
+   * Here the default error strategy is drops `FROM` and makes `Foo` a field
+   * of SELECTs' list. So we don't recognize `Foo` as the SObject we want to
+   * query for.
+   *
+   * We might implement more SOQL-completion-specific logic in the future.
+   */
   protected singleTokenDeletion(recognizer: Parser): Token | undefined {
-    // The default error handling strategy is "too smart" for our code-completion purposes.
-    // We generally do NOT want the parser to remove tokens for recovery.
-    //
-    // Example:
-    //    SELECT id, | FROM Foo
-    //
-    // Here the parser drops `FROM` and makes Foo a field on SELECTs' list
-    // So we don't recognize Foo as the SObject we want to query for.
-    //
-    // We might implement more SOQL-specific logic in the future.
     return undefined;
   }
 }

--- a/packages/language-server/src/completion/SoqlQueryExtractor.ts
+++ b/packages/language-server/src/completion/SoqlQueryExtractor.ts
@@ -1,0 +1,109 @@
+import {
+  SoqlFromExprsContext,
+  SoqlInnerQueryContext,
+  SoqlParser,
+  SoqlQueryContext,
+} from '@salesforce/soql-parser/lib/generated/SoqlParser';
+import { Token } from 'antlr4ts';
+import {
+  ParseTreeWalker,
+  ParseTreeListener,
+  ErrorNode,
+  RuleNode,
+} from 'antlr4ts/tree';
+import { SoqlParserListener } from '@salesforce/soql-parser/lib/generated/SoqlParserListener';
+
+interface InnerSoqlQuery {
+  soqlInnerQueryNode: SoqlInnerQueryContext;
+  select: Token;
+  from?: Token;
+  sobjectName?: string;
+}
+
+export class SoqlQueryExtractor implements SoqlParserListener {
+  selectsStack: Token[] = [];
+  fromsStack: Array<[Token, string]> = [];
+
+  matchedSelectFroms: Array<InnerSoqlQuery> = [];
+
+  innerSoqlQueries = new Map<number, InnerSoqlQuery>();
+
+  constructor(private cursorTokenIndex: number) {}
+
+  static getSObjectFor(
+    parsedQueryTree: SoqlQueryContext,
+    cursorTokenIndex: number
+  ): string | undefined {
+    const listener = new SoqlQueryExtractor(cursorTokenIndex);
+    ParseTreeWalker.DEFAULT.walk<SoqlParserListener>(listener, parsedQueryTree);
+    return listener.findInnerQuery(cursorTokenIndex)?.sobjectName;
+  }
+  private queryContainsTokenIndex(
+    innerQuery: InnerSoqlQuery,
+    atTokenIndex: number
+  ): boolean {
+    // NOTE: We use the parent node to take into account the enclosing
+    // parentheses (in the case of inner SELECTs), and the whole text until EOF
+    // (for the top-level SELECT). BTW: soqlInnerQueryNode always has a parent.
+    const queryNode = innerQuery.soqlInnerQueryNode.parent
+      ? innerQuery.soqlInnerQueryNode.parent
+      : innerQuery.soqlInnerQueryNode;
+
+    const startIndex = queryNode.start.tokenIndex;
+    const stopIndex = queryNode.stop?.tokenIndex;
+
+    return (
+      atTokenIndex > startIndex && !!stopIndex && atTokenIndex <= stopIndex
+    );
+  }
+
+  private findInnerQuery(atIndex: number): InnerSoqlQuery | undefined {
+    let closestQuery: InnerSoqlQuery | undefined;
+    for (let query of this.innerSoqlQueries.values()) {
+      if (this.queryContainsTokenIndex(query, atIndex)) {
+        closestQuery = query;
+      }
+    }
+    return closestQuery;
+  }
+
+  private findSoqlInnerQueryAncestor(
+    node: RuleNode | undefined
+  ): SoqlInnerQueryContext | undefined {
+    let soqlInnerQueryNode = node;
+    while (
+      soqlInnerQueryNode &&
+      soqlInnerQueryNode.ruleContext.ruleIndex !==
+        SoqlParser.RULE_soqlInnerQuery
+    ) {
+      soqlInnerQueryNode = soqlInnerQueryNode.parent;
+    }
+
+    return soqlInnerQueryNode
+      ? (soqlInnerQueryNode as SoqlInnerQueryContext)
+      : undefined;
+  }
+
+  enterSoqlInnerQuery(ctx: SoqlInnerQueryContext) {
+    this.innerSoqlQueries.set(ctx.start.tokenIndex, {
+      select: ctx.start,
+      soqlInnerQueryNode: ctx,
+    });
+  }
+
+  exitSoqlFromExprs(ctx: SoqlFromExprsContext) {
+    const soqlInnerQueryNode = this.findSoqlInnerQueryAncestor(ctx);
+
+    if (ctx.children && ctx.children.length > 0 && soqlInnerQueryNode) {
+      const fromToken = ctx.parent?.start as Token;
+      const sobjectName = ctx.getChild(0).getChild(0).text;
+      const selectFromPair = this.innerSoqlQueries.get(
+        soqlInnerQueryNode.start.tokenIndex
+      );
+      if (selectFromPair) {
+        selectFromPair.from = fromToken;
+        selectFromPair.sobjectName = sobjectName;
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Add basic code-completion for ORDER BY.
Depends on https://github.com/forcedotcom/salesforcedx-vscode/pull/2792

Also:
    * New implementation for extracting data from query (like SObject name),
    * More robust in case of parsing errors (uses custom ANTLR Error Strategy)
    * Better handling of nested queries
    * Better handling of incomplete queries (nested or not)
    * New completions: FOR, OFFSET, LIMIT, ORDER BY, GROUP BY, WITH, WHERE,
                    UPDATE TRACKING, UPDATE VIEWSTAT, COUNT(...), TYPEOF, DISTANCE
    * Refactoring: Extract methods. Move class to new file. Remove old code


![soql_orderby_completion1](https://user-images.githubusercontent.com/152839/102511864-0f282e00-4068-11eb-97b9-31bb9f2fcb66.gif)
![soql_orderby_completion2](https://user-images.githubusercontent.com/152839/102512020-44cd1700-4068-11eb-8189-be4e778e7dd5.gif)

### What issues does this PR fix or reference?
W-8432316