### PR TITLE
Add support for line comments ( `//` ) at the top of SOQL files

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/soql-language-server",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "description": "SOQL Language Server",
   "engines": {
     "node": "*"

--- a/packages/language-server/src/completion.test.ts
+++ b/packages/language-server/src/completion.test.ts
@@ -1008,6 +1008,23 @@ describe('Special cases around newlines', () => {
   );
 });
 
+describe('Support leading comment lines (starting with // )', () => {
+  validateCompletionsFor(
+    `// This a  comment line
+     SELECT id FROM |`,
+    expectedSObjectCompletions
+  );
+});
+describe('Support leading comment lines (starting with // )', () => {
+  validateCompletionsFor(
+    `// This a comment line 1
+     // This a comment line 2
+     // This a comment line 3
+     SELECT id FROM |`,
+    expectedSObjectCompletions
+  );
+});
+
 function validateCompletionsFor(
   text: string,
   expectedItems: CompletionItem[],

--- a/packages/language-server/src/completion.ts
+++ b/packages/language-server/src/completion.ts
@@ -39,6 +39,7 @@ import {
   ParsedSoqlField,
   SoqlQueryAnalyzer,
 } from './completion/soql-query-analysis';
+import { parseHeaderComments } from './soqlComments';
 
 const SOBJECTS_ITEM_LABEL_PLACEHOLDER = '__SOBJECTS_PLACEHOLDER';
 const SOBJECT_FIELDS_LABEL_PLACEHOLDER = '__SOBJECT_FIELDS_PLACEHOLDER';
@@ -56,7 +57,11 @@ export function completionsFor(
   line: number,
   column: number
 ): CompletionItem[] {
-  const lexer = new SoqlLexer(new LowerCasingCharStream(text));
+
+
+  const lexer = new SoqlLexer(
+    new LowerCasingCharStream(parseHeaderComments(text).headerPaddedSoqlText)
+  );
   const tokenStream = new CommonTokenStream(lexer);
   const parser = new SoqlParser(tokenStream);
   parser.removeErrorListeners();

--- a/packages/language-server/src/soqlComments.test.ts
+++ b/packages/language-server/src/soqlComments.test.ts
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (c) 2021, salesforce.com, inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+/**
+ * Note: This file is duplicated at soql-model module
+ * Until we share a common module: if you make a change here,
+ * you might want to make that same change over there
+ */
+
+import { parseHeaderComments } from './soqlComments';
+
+describe('Extract comments at the top of SOQL queries', () => {
+  it('Handle single-line query with no comments', () => {
+    const soqlWithComments = parseHeaderComments(`SELECT Id FROM Account`);
+
+    expect(soqlWithComments.headerComments).toEqual('');
+    expect(soqlWithComments.commentLineCount).toEqual(0);
+    expect(soqlWithComments.soqlText).toEqual(`SELECT Id FROM Account`);
+    expect(soqlWithComments.originalSoqlText).toEqual(`SELECT Id FROM Account`);
+  });
+
+  it('Handle multi-line query with no comments', () => {
+    const soqlWithComments = parseHeaderComments(
+      `SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+
+    expect(soqlWithComments.headerComments).toEqual('');
+    expect(soqlWithComments.commentLineCount).toEqual(0);
+    expect(soqlWithComments.soqlText).toEqual(
+      `SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+    expect(soqlWithComments.originalSoqlText).toEqual(
+      `SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+  });
+
+  it('Handle query with simple comments at the top', () => {
+    const soqlWithComments = parseHeaderComments(
+      `// Comment line 1
+SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+
+    expect(soqlWithComments.headerComments).toEqual('// Comment line 1\n');
+    expect(soqlWithComments.commentLineCount).toEqual(1);
+    expect(soqlWithComments.soqlText).toEqual(
+      `SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+    expect(soqlWithComments.originalSoqlText).toEqual(
+      `// Comment line 1
+SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+  });
+
+  it('Handle query with multi-line comments at the top', () => {
+    const soqlWithComments = parseHeaderComments(
+      `// Comment line 1
+// Comment line2
+// Comment line3
+SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+
+    // NOTE: Empty lines right before the query belong to the comments
+    expect(soqlWithComments.headerComments).toEqual(`// Comment line 1
+// Comment line2
+// Comment line3
+`);
+    expect(soqlWithComments.commentLineCount).toEqual(3);
+    expect(soqlWithComments.soqlText).toEqual(
+      `SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+    expect(soqlWithComments.originalSoqlText).toEqual(
+      `// Comment line 1
+// Comment line2
+// Comment line3
+SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+
+    // NOTE: Empty lines right before the query belong to the comments
+    expect(soqlWithComments.headerComments).toEqual(`// Comment line 1
+// Comment line2
+// Comment line3
+`);
+
+    // NOTE: Empty lines right before the query belong to the comments
+    expect(soqlWithComments.headerComments).toEqual(`// Comment line 1
+// Comment line2
+// Comment line3
+`);
+  });
+
+  it('Handle query with complex comments at the top', () => {
+    const soqlWithComments = parseHeaderComments(
+      `// Comment line 1
+// Comment line2
+
+// Empty lines allows in comments
+   // Leading spaces too
+
+SELECT Id\nFROM Account\nWHERE TRUE
+`
+    );
+
+    // NOTE: Empty lines right before the query belong to the comments
+    expect(soqlWithComments.headerComments).toEqual(`// Comment line 1
+// Comment line2
+
+// Empty lines allows in comments
+   // Leading spaces too
+
+`);
+    expect(soqlWithComments.commentLineCount).toEqual(6);
+    expect(soqlWithComments.soqlText).toEqual(
+      `SELECT Id\nFROM Account\nWHERE TRUE\n`
+    );
+    expect(soqlWithComments.originalSoqlText).toEqual(
+      `// Comment line 1
+// Comment line2
+
+// Empty lines allows in comments
+   // Leading spaces too
+
+SELECT Id\nFROM Account\nWHERE TRUE
+`
+    );
+  });
+});

--- a/packages/language-server/src/soqlComments.ts
+++ b/packages/language-server/src/soqlComments.ts
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2021, salesforce.com, inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+
+/**
+ * Note: This file is duplicated at soql-model module
+ * Until we share a common module: if you make a change here,
+ * you might want to make that same change over there
+ */
+export interface SoqlWithComments {
+  // Original complete SOQL string, untouched:
+  originalSoqlText: string;
+
+  // Comment lines found at the top of the document (may include empty lines):
+  headerComments: string;
+
+  // Number of comment or empty lines found at the top of the document
+  commentLineCount: number;
+
+  // SOQL code with the comment lines at the top replaced by blanks
+  // (to keep the same number of characters and lines for error reporting)
+  headerPaddedSoqlText: string;
+
+  // Pure SOQL code, without comments or empty lines at the top:
+  soqlText: string;
+}
+
+export function parseHeaderComments(
+  originalSoqlText: string
+): SoqlWithComments {
+  const [, headerComments, soqlText] =
+    HEADER_COMMENT_EXTRACTION_REGEX.exec(originalSoqlText) || [];
+
+  const commentLineCount = (headerComments.match(/(\n|\r|\r\n)/g) || []).length;
+  const headerPaddedSoqlText = originalSoqlText.replace(
+    HEADER_COMMENT_EXTRACTION_REGEX,
+    (m, p1, p2) => p1.replace(/[^\n\r]/gm, ' ') + p2
+  );
+
+  const result = {
+    headerComments,
+    headerPaddedSoqlText,
+    soqlText,
+    commentLineCount,
+    originalSoqlText,
+  };
+  return result;
+}
+
+const COMMENT_LINE = /(?:[\s]*\/\/.*?[\r\n])/;
+const EMPTY_LINE = /(?:^[\s]*[\r\n])/;
+const OPTIONAL_HEADER_LINES = new RegExp(
+  '((?:' + COMMENT_LINE.source + '|' + EMPTY_LINE.source + ')*)'
+);
+const ANYTHING = /([^]*)/;
+
+const HEADER_COMMENT_EXTRACTION_REGEX = new RegExp(
+  OPTIONAL_HEADER_LINES.source + ANYTHING.source,
+  'm'
+);

--- a/packages/language-server/src/soqlComments.ts
+++ b/packages/language-server/src/soqlComments.ts
@@ -39,7 +39,8 @@ export function parseHeaderComments(
   const commentLineCount = (headerComments.match(/(\n|\r|\r\n)/g) || []).length;
   const headerPaddedSoqlText = originalSoqlText.replace(
     HEADER_COMMENT_EXTRACTION_REGEX,
-    (m, p1, p2) => p1.replace(/[^\n\r]/gm, ' ') + p2
+    (wholeMatch, headerText, soqlText) =>
+      headerText.replace(/[^\n\r]/gm, ' ') + soqlText
   );
 
   const result = {

--- a/packages/language-server/src/validator.test.ts
+++ b/packages/language-server/src/validator.test.ts
@@ -63,19 +63,20 @@ describe('Validator', () => {
     });
 
     it('creates diagnostic with range when location and cause are returned from API', async () => {
-      const expectedError = `Oh Snap!\nERROR at Row:1:Column:8\nBlame 'Ids' not 'Me'`;
+      const serverError = `Oh Snap!\nERROR at Row:1:Column:8\nBlame 'Ids' not 'Me'`;
+      const expectedErrorWithoutLineColumn = `Oh Snap!\nError:\nBlame 'Ids' not 'Me'`;
       const diagnostics = await Validator.validateLimit0Query(
         mockSOQLDoc('SELECT Ids FROM Account'),
         createMockClientConnection({
           error: {
             name: 'INVALID_FIELD',
             errorCode: 'INVALID_FIELD',
-            message: expectedError,
+            message: serverError,
           },
         })
       );
       expect(diagnostics).toHaveLength(1);
-      expect(diagnostics[0].message).toEqual(expectedError);
+      expect(diagnostics[0].message).toEqual(expectedErrorWithoutLineColumn);
       expect(diagnostics[0].range.start.line).toEqual(0);
       expect(diagnostics[0].range.start.character).toEqual(7);
       expect(diagnostics[0].range.end.line).toEqual(0);
@@ -88,14 +89,15 @@ describe('Validator', () => {
       async () => {
         // The Query API seems to be "ignoring" the initial empty lines, so
         // it reports the error lines as starting from the first non-empty line
-        const expectedError = `Oh Snap!\nERROR at Row:1:Column:8\nBlame 'Ids' not 'Me'`;
+        const serverError = `Oh Snap!\nERROR at Row:1:Column:8\nBlame 'Ids' not 'Me'`;
+        const expectedErrorWithoutLineColumn = `Oh Snap!\nError:\nBlame 'Ids' not 'Me'`;
         const diagnostics = await Validator.validateLimit0Query(
           mockSOQLDoc('\n\n// Comment here\n\nSELECT Ids FROM Account'),
           createMockClientConnection({
             error: {
               name: 'INVALID_FIELD',
               errorCode: 'INVALID_FIELD',
-              message: expectedError,
+              message: serverError,
             },
           })
         );
@@ -105,7 +107,7 @@ describe('Validator', () => {
         const errorLine = 4;
 
         expect(diagnostics).toHaveLength(1);
-        expect(diagnostics[0].message).toEqual(expectedError);
+        expect(diagnostics[0].message).toEqual(expectedErrorWithoutLineColumn);
         expect(diagnostics[0].range.start.line).toEqual(errorLine);
         expect(diagnostics[0].range.start.character).toEqual(7);
         expect(diagnostics[0].range.end.line).toEqual(errorLine);

--- a/packages/language-server/src/validator.test.ts
+++ b/packages/language-server/src/validator.test.ts
@@ -82,6 +82,37 @@ describe('Validator', () => {
       expect(diagnostics[0].range.end.character).toEqual(10);
     });
 
+    it(
+      'creates diagnostic with range when location and cause are returned from API' +
+        ' when query prefixed by newlines',
+      async () => {
+        // The Query API seems to be "ignoring" the initial empty lines, so
+        // it reports the error lines as starting from the first non-empty line
+        const expectedError = `Oh Snap!\nERROR at Row:1:Column:8\nBlame 'Ids' not 'Me'`;
+        const diagnostics = await Validator.validateLimit0Query(
+          mockSOQLDoc('\n\n// Comment here\n\nSELECT Ids FROM Account'),
+          createMockClientConnection({
+            error: {
+              name: 'INVALID_FIELD',
+              errorCode: 'INVALID_FIELD',
+              message: expectedError,
+            },
+          })
+        );
+
+        // The expected error line is: the number of empty lines at the top (4),
+        // plus the reported error line number (1), minus 1 because this is zero based
+        const errorLine = 4;
+
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].message).toEqual(expectedError);
+        expect(diagnostics[0].range.start.line).toEqual(errorLine);
+        expect(diagnostics[0].range.start.character).toEqual(7);
+        expect(diagnostics[0].range.end.line).toEqual(errorLine);
+        expect(diagnostics[0].range.end.character).toEqual(10);
+      }
+    );
+
     it('creates diagnostic with full doc range when location is not found', async () => {
       const expectedError = `Oh Snap!`;
       const diagnostics = await Validator.validateLimit0Query(

--- a/packages/language-server/src/validator.ts
+++ b/packages/language-server/src/validator.ts
@@ -11,6 +11,7 @@ import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { RequestTypes, RunQueryResponse } from './index';
 import { Connection } from 'vscode-languageserver';
+import { parseHeaderComments, SoqlWithComments } from './soqlComments';
 
 const findLimitRegex = new RegExp(/LIMIT\s+\d+\s*$/, 'i');
 const findPositionRegex = new RegExp(
@@ -37,7 +38,9 @@ export class Validator {
       isMultiCurrencyEnabled: true,
       apiVersion: 50.0,
     });
-    const result = parser.parseQuery(textDocument.getText());
+    const result = parser.parseQuery(
+      parseHeaderComments(textDocument.getText()).headerPaddedSoqlText
+    );
     if (!result.getSuccess()) {
       result.getParserErrors().forEach((error) => {
         diagnostics.push({
@@ -61,15 +64,17 @@ export class Validator {
     connection: Connection
   ) {
     const diagnostics: Diagnostic[] = [];
+    const soqlWithHeaderComments = parseHeaderComments(textDocument.getText());
+
     const response = (await connection.sendRequest(
       RequestTypes.RunQuery,
-      appendLimit0(textDocument.getText())
+      appendLimit0(soqlWithHeaderComments.soqlText)
     )) as RunQueryResponse;
     if (response.error) {
       diagnostics.push({
         severity: DiagnosticSeverity.Error,
         range:
-          extractErrorRange(response.error.message) ||
+          extractErrorRange(soqlWithHeaderComments, response.error.message) ||
           documentRange(textDocument),
         message: response.error.message,
         source: 'soql',
@@ -88,10 +93,14 @@ function appendLimit0(query: string): string {
   return query;
 }
 
-function extractErrorRange(errorMessage: string): Range | null {
+function extractErrorRange(
+  soqlWithComments: SoqlWithComments,
+  errorMessage: string
+): Range | null {
   const posMatch = errorMessage.match(findPositionRegex);
   if (posMatch && posMatch.groups) {
-    const line = Number(posMatch.groups.row) - 1;
+    const line =
+      Number(posMatch.groups.row) - 1 + soqlWithComments.commentLineCount;
     const character = Number(posMatch.groups.column) - 1;
     const causeMatch = errorMessage.match(findCauseRegex);
     const cause =

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.ts
@@ -23,7 +23,12 @@ export function convertSoqlToUiModel(soql: string): ToolingModelJson {
 export function convertSoqlModelToUiModel(
   queryModel: Soql.Query
 ): ToolingModelJson {
-  const fields =
+
+  const headerComments = queryModel.headerComments
+    ? queryModel.headerComments.text
+    : undefined;
+
+    const fields =
     queryModel.select &&
     (queryModel.select as Soql.SelectExprs).selectExpressions
       ? (queryModel.select as Soql.SelectExprs).selectExpressions
@@ -69,6 +74,7 @@ export function convertSoqlModelToUiModel(
   }
 
   const toolingModelTemplate: ToolingModelJson = {
+    headerComments: headerComments,
     sObject: sObject || '',
     fields: fields || [],
     orderBy: orderBy || [],
@@ -112,6 +118,9 @@ function convertUiModelToSoqlModel(uiModel: ToolingModelJson): Soql.Query {
     undefined,
     orderBy,
     limit
+  );
+  queryModel.headerComments = new Impl.HeaderCommentsImpl(
+    uiModel.headerComments
   );
   return queryModel;
 }

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.test.ts
@@ -233,4 +233,40 @@ describe('Tooling Model Service', () => {
     const orderBy = modelService.getModel().get('orderBy');
     expect(typeof orderBy.toJS).toEqual('function');
   });
+
+
+  it('Receive SOQL Text from editor (with comments)', () => {
+    const soqlText =
+      '// This is a comment\n\n\n// Another comment\n\nSELECT Id FROM Foo';
+    const soqlEvent = { ...soqlEditorEvent };
+    soqlEvent.payload = soqlText;
+    (messageService.messagesToUI as BehaviorSubject<SoqlEditorEvent>).next(
+      soqlEvent
+    );
+
+    expect(query.sObject).toEqual('Foo');
+    expect(query.fields[0]).toEqual('Id');
+    expect(query.errors.length).toEqual(0);
+    expect(query.unsupported.length).toEqual(0);
+    expect(query.headerComments).toEqual(
+      '// This is a comment\n\n\n// Another comment\n\n'
+    );
+
+    // Now modify the query. The resulting text must retain the comments
+    modelService.setSObject('Bar');
+    modelService.addField('Name');
+
+    expect(query.sObject).toEqual('Bar');
+    expect(query.fields[0]).toEqual('Name');
+
+    expect(query.originalSoqlStatement).toContain(
+      '// This is a comment\n\n\n// Another comment\n\n'
+    );
+    expect(query.originalSoqlStatement).toContain('SELECT Name');
+    expect(query.originalSoqlStatement).toContain('FROM Bar');
+    expect(query.headerComments).toEqual(
+      '// This is a comment\n\n\n// Another comment\n\n'
+    );
+  });
+
 });

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.ts
@@ -22,6 +22,7 @@ import { createQueryTelemetry } from './telemetryUtils';
 type IMap = Map<string, string | List<string>>;
 // Private immutable interface
 export interface ToolingModel extends IMap {
+  headerComments?: string;
   sObject: string;
   fields: List<string>;
   orderBy: List<Map>;
@@ -32,6 +33,7 @@ export interface ToolingModel extends IMap {
 }
 // Public inteface for accessing modelService.query
 export interface ToolingModelJson extends JsonMap {
+  headerComments?: string;
   sObject: string;
   fields: string[];
   orderBy: JsonMap[];
@@ -86,12 +88,17 @@ export class ToolingModelService {
   private getOrderBy() {
     return this.getModel().get('orderBy') as List<JsonMap>;
   }
-  // This method is destructive, will clear any selections except sObject.
+  // This method is destructive, will override any selections with the
+  // template and then set the sObject
   public setSObject(sObject: string) {
-    const emptyModel = fromJS(ToolingModelService.toolingModelTemplate);
-    const newModelWithSelection = emptyModel.set('sObject', sObject);
-
-    this.changeModel(newModelWithSelection);
+    const newModelJS = Object.assign(
+      this.getModel().toJS(),
+      ToolingModelService.toolingModelTemplate,
+      {
+        sObject: sObject
+      }
+    );
+    this.changeModel(fromJS(newModelJS));
   }
 
   public addField(field: string) {

--- a/packages/soql-model/src/model/impl/headerCommentsImpl.ts
+++ b/packages/soql-model/src/model/impl/headerCommentsImpl.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Soql from '../model';
+import { SoqlModelObjectImpl } from './soqlModelObjectImpl';
+
+export class HeaderCommentsImpl
+  extends SoqlModelObjectImpl
+  implements Soql.HeaderComments {
+  public constructor(public text: string) {
+    super();
+  }
+
+  public toSoqlSyntax(options?: Soql.SyntaxOptions): string {
+    return this.text;
+  }
+}

--- a/packages/soql-model/src/model/impl/index.ts
+++ b/packages/soql-model/src/model/impl/index.ts
@@ -16,6 +16,7 @@ import { QueryImpl } from './queryImpl';
 import { SelectExprsImpl } from './selectExprsImpl';
 import { WhereImpl } from './whereImpl';
 import { UnmodeledSyntaxImpl } from './unmodeledSyntaxImpl';
+import { HeaderCommentsImpl } from './headerCommentsImpl';
 
 export {
   AndOrConditionImpl,
@@ -36,4 +37,5 @@ export {
   OrderByExpressionImpl,
   WhereImpl,
   UnmodeledSyntaxImpl,
+  HeaderCommentsImpl,
 };

--- a/packages/soql-model/src/model/impl/queryImpl.ts
+++ b/packages/soql-model/src/model/impl/queryImpl.ts
@@ -10,6 +10,7 @@ import * as Soql from '../model';
 import { SoqlModelObjectImpl } from './soqlModelObjectImpl';
 
 export class QueryImpl extends SoqlModelObjectImpl implements Soql.Query {
+  headerComments?: Soql.HeaderComments;
   public select?: Soql.Select;
   public from?: Soql.From;
   public where?: Soql.Where;
@@ -50,6 +51,9 @@ export class QueryImpl extends SoqlModelObjectImpl implements Soql.Query {
   public toSoqlSyntax(options?: Soql.SyntaxOptions): string {
     const _options = this.getSyntaxOptions(options);
     let syntax = '';
+    if (this.headerComments) {
+      syntax += `${this.headerComments.toSoqlSyntax(options)}`;
+    }
     if (this.select) {
       syntax += `${this.select.toSoqlSyntax(_options)}${os.EOL}`;
     }

--- a/packages/soql-model/src/model/model.ts
+++ b/packages/soql-model/src/model/model.ts
@@ -36,6 +36,7 @@ export class SyntaxOptions {
 }
 
 export interface Query extends SoqlModelObject {
+  headerComments?: HeaderComments;
   select?: Select;
   from?: From;
   where?: Where;
@@ -208,6 +209,9 @@ export interface InListCondition extends Condition {
 
 export interface Where extends SoqlModelObject {
   condition?: Condition;
+}
+export interface HeaderComments extends SoqlModelObject {
+  text: string;
 }
 
 export interface With extends SoqlModelObject { }

--- a/packages/soql-model/src/serialization/deserializer.test.ts
+++ b/packages/soql-model/src/serialization/deserializer.test.ts
@@ -240,6 +240,43 @@ describe('ModelDeserializer should', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('Identify comments at the top of the file', () => {
+    const expected = {
+      headerComments: {
+        text:
+          '// This is a comment on line 1\n// This is a comment on line 2\n',
+      },
+      select: {
+        selectExpressions: [testQueryModel.select.selectExpressions[0]],
+      },
+      from: testQueryModel.from,
+      errors: [],
+    };
+    const actual = new ModelDeserializer(
+      `// This is a comment on line 1\n// This is a comment on line 2\nSELECT field1 FROM object1`
+    ).deserialize();
+    expect(actual).toEqual(expected);
+  });
+
+  it('Identify comments at the top of the file, with parse errors', () => {
+    const expected = {
+      headerComments: {
+        text:
+          '// This is a comment on line 1\n// This is a comment on line 2\n',
+      },
+    };
+    const actual = new ModelDeserializer(
+      `// This is a comment on line 1\n// This is a comment on line 2\nSELECT FROM object1`
+    ).deserialize();
+
+    expect(actual.errors).toBeDefined();
+    expect(actual.errors?.length).toEqual(1);
+    expect(actual.errors && actual.errors[0].lineNumber).toEqual(3);
+    expect(actual.headerComments).toEqual(expected.headerComments);
+  });
+
+
+
   // it('identify string literals in condition', () => {
   //   const expected = {
   //     select: {

--- a/packages/soql-model/src/serialization/deserializer.ts
+++ b/packages/soql-model/src/serialization/deserializer.ts
@@ -21,6 +21,8 @@ import {
   AbstractParseTreeVisitor,
 } from 'antlr4ts/tree';
 import { Interval } from 'antlr4ts/misc/Interval';
+import { HeaderCommentsImpl } from '../model/impl/headerCommentsImpl';
+import { parseHeaderComments } from './soqlComments';
 
 export class ModelDeserializer {
   protected soqlSyntax: string;
@@ -35,13 +37,22 @@ export class ModelDeserializer {
       isMultiCurrencyEnabled: true,
       apiVersion: 50.0,
     });
-    const result = parser.parseQuery(this.soqlSyntax);
+
+
+    const { headerComments, headerPaddedSoqlText } = parseHeaderComments(
+      this.soqlSyntax
+    );
+
+    const result = parser.parseQuery(headerPaddedSoqlText);
     const parseTree = result.getParseTree();
     const errors = result.getParserErrors();
     if (parseTree) {
       const queryListener = new QueryListener();
       parseTree.enterRule(queryListener as ParseTreeListener);
       query = queryListener.getQuery();
+      if (query && headerComments) {
+        query.headerComments = new HeaderCommentsImpl(headerComments);
+      }
     }
 
     const errorIdentifer = new ErrorIdentifier(parseTree);

--- a/packages/soql-model/src/serialization/serializer.test.ts
+++ b/packages/soql-model/src/serialization/serializer.test.ts
@@ -7,6 +7,7 @@
 
 import { ModelSerializer } from './serializer';
 import * as Impl from '../model/impl';
+import { HeaderCommentsImpl } from '../model/impl/headerCommentsImpl';
 
 describe('ModelSerializer should', () => {
   it('transform model to SOQL syntax', () => {
@@ -17,6 +18,21 @@ describe('ModelSerializer should', () => {
         new Impl.FromImpl('object')
       )
     ).serialize();
+    expect(actual).toEqual(expected);
+  });
+
+  it('transform model with comments to SOQL syntax', () => {
+    const expected =
+      '// Comment 1\n// Comment 2\nSELECT field\n  FROM object\n';
+
+    const query = new Impl.QueryImpl(
+      new Impl.SelectExprsImpl([new Impl.FieldRefImpl('field')]),
+      new Impl.FromImpl('object')
+    );
+    query.headerComments = new HeaderCommentsImpl(
+      '// Comment 1\n// Comment 2\n'
+    );
+    const actual = new ModelSerializer(query).serialize();
     expect(actual).toEqual(expected);
   });
 });

--- a/packages/soql-model/src/serialization/soqlComments.test.ts
+++ b/packages/soql-model/src/serialization/soqlComments.test.ts
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (c) 2021, salesforce.com, inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+/**
+ * Note: This file is duplicated at soql's language-server module
+ * Until we share a common module: if you make a change here,
+ * you might want to make that same change over there
+ */
+
+import { parseHeaderComments } from './soqlComments';
+
+describe('Extract comments at the top of SOQL queries', () => {
+  it('Handle single-line query with no comments', () => {
+    const soqlWithComments = parseHeaderComments(`SELECT Id FROM Account`);
+
+    expect(soqlWithComments.headerComments).toEqual('');
+    expect(soqlWithComments.commentLineCount).toEqual(0);
+    expect(soqlWithComments.soqlText).toEqual(`SELECT Id FROM Account`);
+    expect(soqlWithComments.originalSoqlText).toEqual(`SELECT Id FROM Account`);
+  });
+
+  it('Handle multi-line query with no comments', () => {
+    const soqlWithComments = parseHeaderComments(
+      `SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+
+    expect(soqlWithComments.headerComments).toEqual('');
+    expect(soqlWithComments.commentLineCount).toEqual(0);
+    expect(soqlWithComments.soqlText).toEqual(
+      `SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+    expect(soqlWithComments.originalSoqlText).toEqual(
+      `SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+  });
+
+  it('Handle query with simple comments at the top', () => {
+    const soqlWithComments = parseHeaderComments(
+      `// Comment line 1
+SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+
+    expect(soqlWithComments.headerComments).toEqual('// Comment line 1\n');
+    expect(soqlWithComments.commentLineCount).toEqual(1);
+    expect(soqlWithComments.soqlText).toEqual(
+      `SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+    expect(soqlWithComments.originalSoqlText).toEqual(
+      `// Comment line 1
+SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+  });
+
+  it('Handle query with multi-line comments at the top', () => {
+    const soqlWithComments = parseHeaderComments(
+      `// Comment line 1
+// Comment line2
+// Comment line3
+SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+
+    // NOTE: Empty lines right before the query belong to the comments
+    expect(soqlWithComments.headerComments).toEqual(`// Comment line 1
+// Comment line2
+// Comment line3
+`);
+    expect(soqlWithComments.commentLineCount).toEqual(3);
+    expect(soqlWithComments.soqlText).toEqual(
+      `SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+    expect(soqlWithComments.originalSoqlText).toEqual(
+      `// Comment line 1
+// Comment line2
+// Comment line3
+SELECT Id\nFROM Account\nWHERE TRUE`
+    );
+
+    // NOTE: Empty lines right before the query belong to the comments
+    expect(soqlWithComments.headerComments).toEqual(`// Comment line 1
+// Comment line2
+// Comment line3
+`);
+
+    // NOTE: Empty lines right before the query belong to the comments
+    expect(soqlWithComments.headerComments).toEqual(`// Comment line 1
+// Comment line2
+// Comment line3
+`);
+  });
+
+  it('Handle query with complex comments at the top', () => {
+    const soqlWithComments = parseHeaderComments(
+      `// Comment line 1
+// Comment line2
+
+// Empty lines allows in comments
+   // Leading spaces too
+
+SELECT Id\nFROM Account\nWHERE TRUE
+`
+    );
+
+    // NOTE: Empty lines right before the query belong to the comments
+    expect(soqlWithComments.headerComments).toEqual(`// Comment line 1
+// Comment line2
+
+// Empty lines allows in comments
+   // Leading spaces too
+
+`);
+    expect(soqlWithComments.commentLineCount).toEqual(6);
+    expect(soqlWithComments.soqlText).toEqual(
+      `SELECT Id\nFROM Account\nWHERE TRUE\n`
+    );
+    expect(soqlWithComments.originalSoqlText).toEqual(
+      `// Comment line 1
+// Comment line2
+
+// Empty lines allows in comments
+   // Leading spaces too
+
+SELECT Id\nFROM Account\nWHERE TRUE
+`
+    );
+  });
+});

--- a/packages/soql-model/src/serialization/soqlComments.ts
+++ b/packages/soql-model/src/serialization/soqlComments.ts
@@ -39,7 +39,8 @@ export function parseHeaderComments(
   const commentLineCount = (headerComments.match(/(\n|\r|\r\n)/g) || []).length;
   const headerPaddedSoqlText = originalSoqlText.replace(
     HEADER_COMMENT_EXTRACTION_REGEX,
-    (m, p1, p2) => p1.replace(/[^\n\r]/gm, ' ') + p2
+    (wholeMatch, headerText, soqlText) =>
+      headerText.replace(/[^\n\r]/gm, ' ') + soqlText
   );
 
   const result = {

--- a/packages/soql-model/src/serialization/soqlComments.ts
+++ b/packages/soql-model/src/serialization/soqlComments.ts
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2021, salesforce.com, inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+
+/**
+ * Note: This file is duplicated at soql's language-server module
+ * Until we share a common module: if you make a change here,
+ * you might want to make that same change over there
+ */
+export interface SoqlWithComments {
+  // Original complete SOQL string, untouched:
+  originalSoqlText: string;
+
+  // Comment lines found at the top of the document (may include empty lines):
+  headerComments: string;
+
+  // Number of comment or empty lines found at the top of the document
+  commentLineCount: number;
+
+  // SOQL code with the comment lines at the top replaced by blanks
+  // (to keep the same number of characters and lines for error reporting)
+  headerPaddedSoqlText: string;
+
+  // Pure SOQL code, without comments or empty lines at the top:
+  soqlText: string;
+}
+
+export function parseHeaderComments(
+  originalSoqlText: string
+): SoqlWithComments {
+  const [, headerComments, soqlText] =
+    HEADER_COMMENT_EXTRACTION_REGEX.exec(originalSoqlText) || [];
+
+  const commentLineCount = (headerComments.match(/(\n|\r|\r\n)/g) || []).length;
+  const headerPaddedSoqlText = originalSoqlText.replace(
+    HEADER_COMMENT_EXTRACTION_REGEX,
+    (m, p1, p2) => p1.replace(/[^\n\r]/gm, ' ') + p2
+  );
+
+  const result = {
+    headerComments,
+    headerPaddedSoqlText,
+    soqlText,
+    commentLineCount,
+    originalSoqlText,
+  };
+  return result;
+}
+
+const COMMENT_LINE = /(?:[\s]*\/\/.*?[\r\n])/;
+const EMPTY_LINE = /(?:^[\s]*[\r\n])/;
+const OPTIONAL_HEADER_LINES = new RegExp(
+  '((?:' + COMMENT_LINE.source + '|' + EMPTY_LINE.source + ')*)'
+);
+const ANYTHING = /([^]*)/;
+
+const HEADER_COMMENT_EXTRACTION_REGEX = new RegExp(
+  OPTIONAL_HEADER_LINES.source + ANYTHING.source,
+  'm'
+);


### PR DESCRIPTION
### What does this PR do?

Add support for line comments at the top of SOQL files.

NOTE!: syntax highlighting covered separately.

https://user-images.githubusercontent.com/152839/106056947-fe8abf00-60cd-11eb-8857-92d53c3eaa80.mov

Covers:
* The soql model
* The Builder (UI)
* LSP: text completion
* LSP: local syntax validation
* LSP: remote syntax validation

### What issues does this PR fix or reference?
W-8611529

