### PR TITLE
set the error overlay to be on top of all other form elements

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.css
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.css
@@ -58,7 +58,7 @@ main {
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 201; /* one above the custom select options pane */
+  z-index: 2; /* one above the custom select options pane */
   background-color: var(
     --vscode-inputValidation-warningBackground,
     var(--soql-error-background)

--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.css
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.css
@@ -52,6 +52,7 @@ main {
   opacity: 0.5;
   background-color: rgba(0, 0, 0, 0.6);
   border-radius: 3px;
+  z-index: 2; /* one above the custom select options pane */
 }
 
 .block-message {

--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.html
@@ -9,29 +9,14 @@
 <template>
   <main>
     <header class="querybuilder-header">
-      <querybuilder-header class={theme} onrunquery={handleRunQuery} is-running={isQueryRunning}></querybuilder-header>
+      <querybuilder-header
+        class={theme}
+        onrunquery={handleRunQuery}
+        is-running={isQueryRunning}
+      ></querybuilder-header>
     </header>
     <article class="querybuilder-body">
       <section class="querybuilder-form">
-          <template if:true={blockQueryBuilder}>
-            <div class="unsupported-syntax">
-            </div>
-            <template if:true={hasUnsupported}>
-              <!-- TODO: i18n -->
-              <div class="block-message">
-                <h3>Syntax Not Yet Supported</h3>
-                <p>Your query contains statements that SOQL Builder doesn't currently support.  You can still run the query but must use a text editor to change it.</p>
-              </div>
-            </template>
-            <template if:true={hasUnrecoverable}>
-              <!-- TODO: i18n -->
-              <div class="block-message">
-                <h3>Syntax Error</h3>
-                <p>Your SOQL statement contains syntax errors. Use a text editor to edit the query, and try again.</p>
-              </div>
-            </template>
-
-        </template>
         <querybuilder-from
           onobjectselected={handleObjectChange}
           sobjects={sObjects}
@@ -64,9 +49,39 @@
           onlimitchanged={handleLimitChanged}
           class={theme}
         ></querybuilder-limit>
+        <!-- div.unsupported-syntax should always be
+        last in the <section class="querybuilder-form">
+        So it stays on top of form elements -->
+        <template if:true={blockQueryBuilder}>
+          <div class="unsupported-syntax"></div>
+          <template if:true={hasUnsupported}>
+            <!-- TODO: i18n -->
+            <div class="block-message">
+              <h3>Syntax Not Yet Supported</h3>
+              <p>
+                Your query contains statements that SOQL Builder doesn't
+                currently support. You can still run the query but must use a
+                text editor to change it.
+              </p>
+            </div>
+          </template>
+          <template if:true={hasUnrecoverable}>
+            <!-- TODO: i18n -->
+            <div class="block-message">
+              <h3>Syntax Error</h3>
+              <p>
+                Your SOQL statement contains syntax errors. Use a text editor to
+                edit the query, and try again.
+              </p>
+            </div>
+          </template>
+        </template>
       </section>
       <section class="query-preview">
-        <querybuilder-query-preview class={theme} soql-statement={query.originalSoqlStatement}></querybuilder-query-preview>
+        <querybuilder-query-preview
+          class={theme}
+          soql-statement={query.originalSoqlStatement}
+        ></querybuilder-query-preview>
       </section>
     </article>
   </main>

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.css
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.css
@@ -88,7 +88,7 @@ div.select__dropdown-arrow:focus {
   opacity: 0;
   transition: opacity 0.2s;
   pointer-events: none;
-  z-index: 200;
+  z-index: 1;
   background-color: var(--vscode-sideBar-background, var(--soql-background));
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR will refactor the use of `x-index` for some UI components. It will also move the error overlay to the further down the DOM of the form section so that it sits on top of other siblings.

