### PR TITLE
Human readable messages for unsupported syntax

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { Soql } from '@salesforce/soql-model';
 import {
   convertUiModelToSoql,
   convertSoqlToUiModel,
@@ -63,7 +64,7 @@ describe('SoqlUtils', () => {
     unsupported: [
       {
         unmodeledSyntax: 'GROUP BY',
-        reason: 'unmodeled:group-by'
+        reason: Soql.REASON_UNMODELED_GROUPBY
       }
     ],
     originalSoqlStatement: ''
@@ -111,7 +112,9 @@ describe('SoqlUtils', () => {
     const transformedUiModel = convertSoqlToUiModel(unsupportedWhereExpr);
     expect(transformedUiModel.where.conditions.length).toBe(0);
     expect(transformedUiModel.unsupported.length).toBe(1);
-    expect(transformedUiModel.unsupported[0].reason).toEqual('unmodeled:complex-group');
+    expect(transformedUiModel.unsupported[0].reason).toEqual(
+      Soql.REASON_UNMODELED_COMPLEXGROUP
+    );
   });
 
   it('transforms Soql to UI Model with errors in soql syntax', () => {

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/telemetryUtils.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/telemetryUtils.test.ts
@@ -1,3 +1,4 @@
+import { Soql } from '@salesforce/soql-model';
 import { createQueryTelemetry } from './telemetryUtils';
 import { ToolingModelJson } from './toolingModelService';
 
@@ -20,11 +21,11 @@ describe('Telemetry Utils', () => {
   };
   const unsupported1 = {
     unmodeledSyntax: 'GROUP BY\n  ORDER',
-    reason: 'unmodeled:group-by'
+    reason: Soql.REASON_UNMODELED_GROUPBY
   };
   const unsupported2 = {
     unmodeledSyntax: 'COUNT(Id) recordCount',
-    reason: 'unmodeled:function-reference'
+    reason: Soql.REASON_UNMODELED_FUNCTIONREFERENCE
   };
 
   const query = ({
@@ -43,7 +44,7 @@ describe('Telemetry Utils', () => {
     expect(telemetry.errors.length).toEqual(query.errors.length);
     expect(telemetry.errors[0]).toContain(error1.grammarRule);
     expect(telemetry.unsupported.length).toEqual(query.unsupported.length);
-    expect(telemetry.unsupported[0]).toEqual(unsupported1.reason);
+    expect(telemetry.unsupported[0]).toEqual(unsupported1.reason.reasonCode);
     expect(JSON.stringify(telemetry)).not.toContain(query.fields[0]);
   });
 });

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/telemetryUtils.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/telemetryUtils.ts
@@ -21,6 +21,6 @@ export function createQueryTelemetry(
   telemetry.errors = query.errors.map(
     (err) => `${err.type}:${err.grammarRule}`
   );
-  telemetry.unsupported = query.unsupported.map((unsup) => unsup.reason);
+  telemetry.unsupported = query.unsupported.map((unsup) => unsup.reason.reasonCode);
   return telemetry;
 }

--- a/packages/soql-model/src/messages/messages.ts
+++ b/packages/soql-model/src/messages/messages.ts
@@ -33,4 +33,27 @@ export namespace Messages {
   export const error_fieldInput_list = 'Input must be a comma separated list of values';
 
   export const error_operatorInput = "{0} operator can't be used for this field type";
+
+  export const unmodeled_as = 'Object alias';
+  export const unmodeled_using = 'USING SCOPE clause';
+  export const unmodeled_alias = 'Field alias';
+  export const unmodeled_semijoin = 'Subquery';
+  export const unmodeled_typeof = 'TYPEOF clause';
+  export const unmodeled_distance = 'DISTANCE expression';
+  export const unmodeled_select = 'Unsupported SELECT expression';
+  export const unmodeled_complexgroup = 'Complex condition containing NOT or a mix of AND and OR';
+  export const unmodeled_count = 'COUNT function';
+  export const unmodeled_with = 'WITH filtering expression';
+  export const unmodeled_groupby = 'GROUP BY clause';
+  export const unmodeled_offset = 'OFFSET clause';
+  export const unmodeled_bind = 'BIND clause';
+  export const unmodeled_recordtracking = 'Record tracking clause';
+  export const unmodeled_update = 'Update statistics clause';
+  export const unmodeled_functionreference = 'Function expression';
+  export const unmodeled_colonexpression = 'Colon expression';
+  export const unmodeled_emptycondition = 'Empty condition';
+  export const unmodeled_calculatedcondition = 'Calculated condition field';
+  export const unmodeled_distancecondition = 'DISTANCE condition';
+  export const unmodeled_incolonexpressioncondition = 'Colon expression as IN value';
+  export const unmodeled_insemijoincondition = 'Subquery as IN value';
 }

--- a/packages/soql-model/src/model/impl/fieldSelectionImpl.test.ts
+++ b/packages/soql-model/src/model/impl/fieldSelectionImpl.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as Soql from '../model';
 import * as Impl from '.';
 
 describe('FieldSelectionImpl should', () => {
@@ -14,10 +15,10 @@ describe('FieldSelectionImpl should', () => {
     expect(actual).toEqual(expected);
   });
   it('store an unmodeled syntax object as the alias', () => {
-    const expected = { field: { fieldName: 'brian' }, alias: { unmodeledSyntax: 'bill', reason: 'unmodeled:alias' } };
+    const expected = { field: { fieldName: 'brian' }, alias: { unmodeledSyntax: 'bill', reason: Soql.REASON_UNMODELED_ALIAS } };
     const actual = new Impl.FieldSelectionImpl(
       new Impl.FieldRefImpl(expected.field.fieldName),
-      new Impl.UnmodeledSyntaxImpl(expected.alias.unmodeledSyntax, 'unmodeled:alias')
+      new Impl.UnmodeledSyntaxImpl(expected.alias.unmodeledSyntax, Soql.REASON_UNMODELED_ALIAS)
     );
     expect(actual).toEqual(expected);
   });
@@ -25,7 +26,7 @@ describe('FieldSelectionImpl should', () => {
     const expected = 'rolling stones';
     const actual = new Impl.FieldSelectionImpl(
       new Impl.FieldRefImpl('rolling'),
-      new Impl.UnmodeledSyntaxImpl('stones', 'unmodeled:alias')
+      new Impl.UnmodeledSyntaxImpl('stones', Soql.REASON_UNMODELED_ALIAS)
     ).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });

--- a/packages/soql-model/src/model/impl/fromImpl.test.ts
+++ b/packages/soql-model/src/model/impl/fromImpl.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as Soql from '../model';
 import * as Impl from '.';
 
 describe('FromImpl should', () => {
@@ -16,13 +17,13 @@ describe('FromImpl should', () => {
   it('store as and using clauses as unmodeled syntax', () => {
     const expected = {
       sobjectName: 'black',
-      as: { unmodeledSyntax: 'and', reason: 'unmodeled:as' },
-      using: { unmodeledSyntax: 'blue', reason: 'unmodeled:using' },
+      as: { unmodeledSyntax: 'and', reason: Soql.REASON_UNMODELED_AS },
+      using: { unmodeledSyntax: 'blue', reason: Soql.REASON_UNMODELED_USING },
     };
     const actual = new Impl.FromImpl(
       expected.sobjectName,
-      new Impl.UnmodeledSyntaxImpl(expected.as.unmodeledSyntax, 'unmodeled:as'),
-      new Impl.UnmodeledSyntaxImpl(expected.using.unmodeledSyntax, 'unmodeled:using')
+      new Impl.UnmodeledSyntaxImpl(expected.as.unmodeledSyntax, Soql.REASON_UNMODELED_AS),
+      new Impl.UnmodeledSyntaxImpl(expected.using.unmodeledSyntax, Soql.REASON_UNMODELED_USING)
     );
     expect(actual).toEqual(expected);
   });
@@ -30,8 +31,8 @@ describe('FromImpl should', () => {
     const expected = 'FROM exile on main';
     const actual = new Impl.FromImpl(
       'exile',
-      new Impl.UnmodeledSyntaxImpl('on', 'unmodeled:as'),
-      new Impl.UnmodeledSyntaxImpl('main', 'unmodeled:using')
+      new Impl.UnmodeledSyntaxImpl('on', Soql.REASON_UNMODELED_AS),
+      new Impl.UnmodeledSyntaxImpl('main', Soql.REASON_UNMODELED_USING)
     ).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });

--- a/packages/soql-model/src/model/impl/queryImpl.test.ts
+++ b/packages/soql-model/src/model/impl/queryImpl.test.ts
@@ -6,7 +6,7 @@
  */
 
 import * as Impl from '.';
-import { ConditionOperator, LiteralType } from '../model';
+import * as Soql from '../model';
 
 describe('QueryImpl should', () => {
   it('store query components as appropriate model objects', () => {
@@ -14,31 +14,31 @@ describe('QueryImpl should', () => {
       select: { selectExpressions: [] },
       from: { sobjectName: 'songs' },
       where: { condition: { field: { fieldName: 'paint_it' }, operator: '=', compareValue: { type: 'STRING', value: "'black'" } } },
-      with: { unmodeledSyntax: 'gimme shelter', reason: 'unmodeled:with' },
-      groupBy: { unmodeledSyntax: 'start me up', reason: 'unmodeled:group-by' },
+      with: { unmodeledSyntax: 'gimme shelter', reason: Soql.REASON_UNMODELED_WITH },
+      groupBy: { unmodeledSyntax: 'start me up', reason: Soql.REASON_UNMODELED_GROUPBY },
       orderBy: { orderByExpressions: [{ field: { fieldName: 'angie' } }] },
       limit: { limit: 5 },
-      offset: { unmodeledSyntax: 'wild horses', reason: 'unmodeled:offset' },
-      bind: { unmodeledSyntax: 'miss you', reason: 'unmodeled:bind' },
-      recordTrackingType: { unmodeledSyntax: 'satisfaction', reason: 'unmodeled:record-tracking' },
-      update: { unmodeledSyntax: 'under my thumb', reason: 'unmodeled:update' },
+      offset: { unmodeledSyntax: 'wild horses', reason: Soql.REASON_UNMODELED_OFFSET },
+      bind: { unmodeledSyntax: 'miss you', reason: Soql.REASON_UNMODELED_BIND },
+      recordTrackingType: { unmodeledSyntax: 'satisfaction', reason: Soql.REASON_UNMODELED_RECORDTRACKING },
+      update: { unmodeledSyntax: 'under my thumb', reason: Soql.REASON_UNMODELED_UPDATE },
     };
     const actual = new Impl.QueryImpl(
       new Impl.SelectExprsImpl([]),
       new Impl.FromImpl(expected.from.sobjectName),
       new Impl.WhereImpl(new Impl.FieldCompareConditionImpl(
         new Impl.FieldRefImpl(expected.where.condition.field.fieldName),
-        ConditionOperator.Equals,
-        new Impl.LiteralImpl(LiteralType.String, expected.where.condition.compareValue.value)
+        Soql.ConditionOperator.Equals,
+        new Impl.LiteralImpl(Soql.LiteralType.String, expected.where.condition.compareValue.value)
       )),
-      new Impl.UnmodeledSyntaxImpl(expected.with.unmodeledSyntax, 'unmodeled:with'),
-      new Impl.UnmodeledSyntaxImpl(expected.groupBy.unmodeledSyntax, 'unmodeled:group-by'),
+      new Impl.UnmodeledSyntaxImpl(expected.with.unmodeledSyntax, Soql.REASON_UNMODELED_WITH),
+      new Impl.UnmodeledSyntaxImpl(expected.groupBy.unmodeledSyntax, Soql.REASON_UNMODELED_GROUPBY),
       new Impl.OrderByImpl([new Impl.OrderByExpressionImpl(new Impl.FieldRefImpl(expected.orderBy.orderByExpressions[0].field.fieldName))]),
       new Impl.LimitImpl(expected.limit.limit),
-      new Impl.UnmodeledSyntaxImpl(expected.offset.unmodeledSyntax, 'unmodeled:offset'),
-      new Impl.UnmodeledSyntaxImpl(expected.bind.unmodeledSyntax, 'unmodeled:bind'),
-      new Impl.UnmodeledSyntaxImpl(expected.recordTrackingType.unmodeledSyntax, 'unmodeled:record-tracking'),
-      new Impl.UnmodeledSyntaxImpl(expected.update.unmodeledSyntax, 'unmodeled:update')
+      new Impl.UnmodeledSyntaxImpl(expected.offset.unmodeledSyntax, Soql.REASON_UNMODELED_OFFSET),
+      new Impl.UnmodeledSyntaxImpl(expected.bind.unmodeledSyntax, Soql.REASON_UNMODELED_BIND),
+      new Impl.UnmodeledSyntaxImpl(expected.recordTrackingType.unmodeledSyntax, Soql.REASON_UNMODELED_RECORDTRACKING),
+      new Impl.UnmodeledSyntaxImpl(expected.update.unmodeledSyntax, Soql.REASON_UNMODELED_UPDATE)
     );
     expect(actual).toEqual(expected);
   });
@@ -49,8 +49,8 @@ describe('QueryImpl should', () => {
       new Impl.FromImpl('songs'),
       new Impl.WhereImpl(new Impl.FieldCompareConditionImpl(
         new Impl.FieldRefImpl('paint_it'),
-        ConditionOperator.Equals,
-        new Impl.LiteralImpl(LiteralType.String, "'black'")
+        Soql.ConditionOperator.Equals,
+        new Impl.LiteralImpl(Soql.LiteralType.String, "'black'")
       ))
     ).toSoqlSyntax();
     expect(actual).toEqual(expected);

--- a/packages/soql-model/src/model/impl/soqlModelObjectImpl.test.ts
+++ b/packages/soql-model/src/model/impl/soqlModelObjectImpl.test.ts
@@ -9,7 +9,7 @@ import * as Impl from '.';
 import { SyntaxOptions } from '../model';
 
 describe('SoqlModelObjectImpl should', () => {
-  const testModelObject = new Impl.UnmodeledSyntaxImpl('mick', 'fake SOQL');
+  const testModelObject = new Impl.UnmodeledSyntaxImpl('mick', { reasonCode: 'unmodeled:fake', message: 'fake SOQL' });
   it('use SyntaxOptions that are passed in', () => {
     const expectedSyntaxOptions = new SyntaxOptions();
     expectedSyntaxOptions.indent = 50;

--- a/packages/soql-model/src/model/impl/unmodeledSyntaxImpl.test.ts
+++ b/packages/soql-model/src/model/impl/unmodeledSyntaxImpl.test.ts
@@ -9,13 +9,13 @@ import * as Impl from '.';
 
 describe('UnmodeledSyntaxImpl should', () => {
   it('store a string as unmodeledSyntax', () => {
-    const expected = { unmodeledSyntax: 'ronnie', reason: 'fake SOQL' };
-    const actual = new Impl.UnmodeledSyntaxImpl(expected.unmodeledSyntax, 'fake SOQL');
+    const expected = { unmodeledSyntax: 'ronnie', reason: { reasonCode: 'unmodeled:fake', message: 'fake SOQL' } };
+    const actual = new Impl.UnmodeledSyntaxImpl(expected.unmodeledSyntax, expected.reason);
     expect(actual).toEqual(expected);
   });
   it('return stored syntax for toSoqlSyntax()', () => {
     const expected = 'keith';
-    const actual = new Impl.UnmodeledSyntaxImpl(expected, 'fake SOQL').toSoqlSyntax();
+    const actual = new Impl.UnmodeledSyntaxImpl(expected, { reasonCode: 'unmodeled:fake', message: 'fake SOQL' }).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });
 });

--- a/packages/soql-model/src/model/impl/unmodeledSyntaxImpl.ts
+++ b/packages/soql-model/src/model/impl/unmodeledSyntaxImpl.ts
@@ -6,11 +6,12 @@
  */
 
 import * as Soql from '../model';
+import { UnmodeledSyntaxReason } from '../unmodeled';
 import { SoqlModelObjectImpl } from './soqlModelObjectImpl';
 
 export class UnmodeledSyntaxImpl extends SoqlModelObjectImpl
   implements Soql.UnmodeledSyntax {
-  public constructor(public unmodeledSyntax: string, public reason: string) {
+  public constructor(public unmodeledSyntax: string, public reason: UnmodeledSyntaxReason) {
     super();
   }
   public toSoqlSyntax(options?: Soql.SyntaxOptions): string {

--- a/packages/soql-model/src/model/model.ts
+++ b/packages/soql-model/src/model/model.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import * as Parser from '@salesforce/soql-parser';
+import { UnmodeledSyntaxReason } from './unmodeled';
 
 
 export interface ModelError {
@@ -254,5 +254,7 @@ export interface UnmodeledSyntax
   RecordTrackingType,
   Update {
   unmodeledSyntax: string;
-  reason: string;
+  reason: UnmodeledSyntaxReason;
 }
+
+export * from './unmodeled';

--- a/packages/soql-model/src/model/unmodeled.ts
+++ b/packages/soql-model/src/model/unmodeled.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Messages } from '../messages/messages';
+
+export interface UnmodeledSyntaxReason {
+  reasonCode: string;
+  message: string;
+}
+
+export const REASON_UNMODELED_AS: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:as',
+  message: Messages.unmodeled_as
+};
+export const REASON_UNMODELED_USING: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:using',
+  message: Messages.unmodeled_using
+};
+export const REASON_UNMODELED_ALIAS: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:alias',
+  message: Messages.unmodeled_alias
+};
+export const REASON_UNMODELED_SEMIJOIN: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:semi-join',
+  message: Messages.unmodeled_semijoin
+};
+export const REASON_UNMODELED_TYPEOF: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:type-of',
+  message: Messages.unmodeled_typeof
+};
+export const REASON_UNMODELED_DISTANCE: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:distance',
+  message: Messages.unmodeled_distance
+};
+export const REASON_UNMODELED_SELECT: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:select',
+  message: Messages.unmodeled_select
+};
+export const REASON_UNMODELED_COMPLEXGROUP: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:complex-group',
+  message: Messages.unmodeled_complexgroup
+};
+export const REASON_UNMODELED_COUNT: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:count',
+  message: Messages.unmodeled_count
+};
+export const REASON_UNMODELED_WITH: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:with',
+  message: Messages.unmodeled_with
+};
+export const REASON_UNMODELED_GROUPBY: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:group-by',
+  message: Messages.unmodeled_groupby
+};
+export const REASON_UNMODELED_OFFSET: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:offset',
+  message: Messages.unmodeled_offset
+};
+export const REASON_UNMODELED_BIND: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:bind',
+  message: Messages.unmodeled_bind
+};
+export const REASON_UNMODELED_RECORDTRACKING: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:record-tracking',
+  message: Messages.unmodeled_recordtracking
+};
+export const REASON_UNMODELED_UPDATE: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:update',
+  message: Messages.unmodeled_update
+};
+export const REASON_UNMODELED_FUNCTIONREFERENCE: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:function-reference',
+  message: Messages.unmodeled_functionreference
+};
+export const REASON_UNMODELED_COLONEXPRESSION: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:colon-expression',
+  message: Messages.unmodeled_colonexpression
+};
+export const REASON_UNMODELED_EMPTYCONDITION: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:empty-condition',
+  message: Messages.unmodeled_emptycondition
+};
+export const REASON_UNMODELED_CALCULATEDCONDITION: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:calculated-condition',
+  message: Messages.unmodeled_calculatedcondition
+};
+export const REASON_UNMODELED_DISTANCECONDITION: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:distance-condition',
+  message: Messages.unmodeled_distancecondition
+};
+export const REASON_UNMODELED_INCOLONEXPRESSIONCONDITION: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:in-colon-expression-condition',
+  message: Messages.unmodeled_incolonexpressioncondition
+};
+export const REASON_UNMODELED_INSEMIJOINCONDITION: UnmodeledSyntaxReason = {
+  reasonCode: 'unmodeled:in-semi-join-condition',
+  message: Messages.unmodeled_insemijoincondition
+};

--- a/packages/soql-model/src/model/util.test.ts
+++ b/packages/soql-model/src/model/util.test.ts
@@ -33,7 +33,7 @@ const conditionIncludes = new Impl.IncludesConditionImpl(
 );
 const conditionUnmodeled = new Impl.UnmodeledSyntaxImpl(
   'A + B > 10',
-  'unmodeled:calculated-condition'
+  Soql.REASON_UNMODELED_CALCULATEDCONDITION
 );
 const conditionAndOr = new Impl.AndOrConditionImpl(
   conditionFieldCompare,
@@ -46,7 +46,7 @@ const conditionNot = new Impl.NotConditionImpl(conditionFieldCompare);
 describe('SoqlModelUtils should', () => {
   it('isUnmodeledSyntax should return true if the model object is unmodeled syntax', () => {
     const actual = SoqlModelUtils.isUnmodeledSyntax(
-      new Impl.UnmodeledSyntaxImpl('foo', 'unmodeled:foo')
+      new Impl.UnmodeledSyntaxImpl('foo', { reasonCode: 'unmodeled:foo', message: 'foo' })
     );
     expect(actual).toBeTruthy();
   });
@@ -56,7 +56,7 @@ describe('SoqlModelUtils should', () => {
         new Impl.SelectExprsImpl([
           new Impl.FieldSelectionImpl(
             new Impl.FieldRefImpl('field1'),
-            new Impl.UnmodeledSyntaxImpl('alias1', 'unmodeled:alias')
+            new Impl.UnmodeledSyntaxImpl('alias1', Soql.REASON_UNMODELED_ALIAS)
           ),
         ]),
         new Impl.FromImpl('object1')
@@ -70,7 +70,7 @@ describe('SoqlModelUtils should', () => {
         new Impl.SelectExprsImpl([
           new Impl.FieldSelectionImpl(
             new Impl.FieldRefImpl('field1'),
-            new Impl.UnmodeledSyntaxImpl('alias1', 'unmodeled:alias')
+            new Impl.UnmodeledSyntaxImpl('alias1', Soql.REASON_UNMODELED_ALIAS)
           ),
         ]),
         new Impl.FromImpl('object1')
@@ -81,11 +81,11 @@ describe('SoqlModelUtils should', () => {
   it('returns an array explaining what is unsupported', () => {
     const unmodeled1 = {
       syntax: 'alias',
-      reason: 'unmodeled:alias',
+      reason: Soql.REASON_UNMODELED_ALIAS,
     };
     const unmodeled2 = {
       syntax: 'COUNT(Id) recordCount',
-      reason: 'unmodeled:function-reference',
+      reason: Soql.REASON_UNMODELED_FUNCTIONREFERENCE
     };
     const actual = SoqlModelUtils.getUnmodeledSyntax(
       new Impl.QueryImpl(

--- a/packages/soql-model/src/serialization/deserializer.test.ts
+++ b/packages/soql-model/src/serialization/deserializer.test.ts
@@ -6,23 +6,23 @@
  */
 
 import { ModelDeserializer } from './deserializer';
-import { ErrorType } from '../model/model';
+import * as Soql from '../model/model';
 
 const testQueryModel = {
   select: {
     selectExpressions: [
       { field: { fieldName: 'field1' } },
       { field: { fieldName: 'field2' } },
-      { field: { fieldName: 'field3' }, alias: { unmodeledSyntax: 'alias3', reason: 'unmodeled:alias' } },
-      { unmodeledSyntax: 'COUNT(fieldZ)', reason: 'unmodeled:function-reference' },
-      { unmodeledSyntax: '(SELECT fieldA FROM objectA)', reason: 'unmodeled:semi-join' },
-      { unmodeledSyntax: 'TYPEOF obj WHEN typeX THEN fieldX ELSE fieldY END', reason: 'unmodeled:type-of' },
+      { field: { fieldName: 'field3' }, alias: { unmodeledSyntax: 'alias3', reason: Soql.REASON_UNMODELED_ALIAS } },
+      { unmodeledSyntax: 'COUNT(fieldZ)', reason: Soql.REASON_UNMODELED_FUNCTIONREFERENCE },
+      { unmodeledSyntax: '(SELECT fieldA FROM objectA)', reason: Soql.REASON_UNMODELED_SEMIJOIN },
+      { unmodeledSyntax: 'TYPEOF obj WHEN typeX THEN fieldX ELSE fieldY END', reason: Soql.REASON_UNMODELED_TYPEOF },
     ],
   },
   from: { sobjectName: 'object1' },
   where: { condition: { field: { fieldName: 'field1' }, operator: '=', compareValue: { type: 'NUMBER', value: '5' } } },
-  with: { unmodeledSyntax: 'WITH DATA CATEGORY cat__c AT val__c', reason: 'unmodeled:with' },
-  groupBy: { unmodeledSyntax: 'GROUP BY field1', reason: 'unmodeled:group-by' },
+  with: { unmodeledSyntax: 'WITH DATA CATEGORY cat__c AT val__c', reason: Soql.REASON_UNMODELED_WITH },
+  groupBy: { unmodeledSyntax: 'GROUP BY field1', reason: Soql.REASON_UNMODELED_GROUPBY },
   orderBy: {
     orderByExpressions: [
       { field: { fieldName: 'field2' }, order: 'DESC', nullsOrder: 'NULLS LAST' },
@@ -30,20 +30,20 @@ const testQueryModel = {
     ]
   },
   limit: { limit: 20 },
-  offset: { unmodeledSyntax: 'OFFSET 2', reason: 'unmodeled:offset' },
-  bind: { unmodeledSyntax: 'BIND field1 = 5', reason: 'unmodeled:bind' },
-  recordTrackingType: { unmodeledSyntax: 'FOR VIEW', reason: 'unmodeled:record-tracking' },
-  update: { unmodeledSyntax: 'UPDATE TRACKING', reason: 'unmodeled:update' },
+  offset: { unmodeledSyntax: 'OFFSET 2', reason: Soql.REASON_UNMODELED_OFFSET },
+  bind: { unmodeledSyntax: 'BIND field1 = 5', reason: Soql.REASON_UNMODELED_BIND },
+  recordTrackingType: { unmodeledSyntax: 'FOR VIEW', reason: Soql.REASON_UNMODELED_RECORDTRACKING },
+  update: { unmodeledSyntax: 'UPDATE TRACKING', reason: Soql.REASON_UNMODELED_UPDATE },
   errors: [],
 };
 
 const fromWithUnmodeledSyntax = {
   sobjectName: 'object1',
-  as: { unmodeledSyntax: 'AS objectAs', reason: 'unmodeled:as' },
-  using: { unmodeledSyntax: 'USING SCOPE everything', reason: 'unmodeled:using' },
+  as: { unmodeledSyntax: 'AS objectAs', reason: Soql.REASON_UNMODELED_AS },
+  using: { unmodeledSyntax: 'USING SCOPE everything', reason: Soql.REASON_UNMODELED_USING },
 };
 
-const selectCountUnmdeledSyntax = { unmodeledSyntax: 'SELECT COUNT()', reason: 'unmodeled:count' };
+const selectCountUnmdeledSyntax = { unmodeledSyntax: 'SELECT COUNT()', reason: Soql.REASON_UNMODELED_COUNT };
 
 const limitZero = { limit: 0 };
 
@@ -63,11 +63,11 @@ const conditionInList = { field, operator: 'IN', values: [literalString, { ...li
 const conditionIncludes = { field, operator: 'INCLUDES', values: [literalString, { ...literalString, value: "'other value'" }] };
 const conditionAndOr = { leftCondition: conditionFieldCompare, andOr: 'AND', rightCondition: conditionLike };
 const conditionNested = { condition: conditionFieldCompare };
-const conditionNot = { unmodeledSyntax: 'NOT field = 5', reason: 'unmodeled:complex-group' };
-const conditionComplex = { unmodeledSyntax: 'field = 5 AND (field like \'A%\' OR field like \'B%\')', reason: 'unmodeled:complex-group' };
-const conditionCalculated = { unmodeledSyntax: 'A + B > 10', reason: 'unmodeled:calculated-condition' };
-const conditionDistance = { unmodeledSyntax: "DISTANCE(field,GEOLOCATION(37,122),'mi') < 100", reason: 'unmodeled:distance-condition' };
-const conditionSemiJoin = { unmodeledSyntax: 'field IN (SELECT A FROM B)', reason: 'unmodeled:in-semi-join-condition' };
+const conditionNot = { unmodeledSyntax: 'NOT field = 5', reason: Soql.REASON_UNMODELED_COMPLEXGROUP };
+const conditionComplex = { unmodeledSyntax: 'field = 5 AND (field like \'A%\' OR field like \'B%\')', reason: Soql.REASON_UNMODELED_COMPLEXGROUP };
+const conditionCalculated = { unmodeledSyntax: 'A + B > 10', reason: Soql.REASON_UNMODELED_CALCULATEDCONDITION };
+const conditionDistance = { unmodeledSyntax: "DISTANCE(field,GEOLOCATION(37,122),'mi') < 100", reason: Soql.REASON_UNMODELED_DISTANCECONDITION };
+const conditionSemiJoin = { unmodeledSyntax: 'field IN (SELECT A FROM B)', reason: Soql.REASON_UNMODELED_INSEMIJOINCONDITION };
 
 describe('ModelDeserializer should', () => {
   it('model supported syntax as query objects', () => {
@@ -154,31 +154,31 @@ describe('ModelDeserializer should', () => {
   });
 
   it('identify no selections error', () => {
-    expectError('SELECT FROM object1', ErrorType.NOSELECTIONS);
+    expectError('SELECT FROM object1', Soql.ErrorType.NOSELECTIONS);
   });
 
   it('identify no SELECT clause error', () => {
-    expectError('FROM object1', ErrorType.NOSELECT);
+    expectError('FROM object1', Soql.ErrorType.NOSELECT);
   });
 
   it('identify incomplete FROM clause error', () => {
-    expectError('SELECT A FROM ', ErrorType.INCOMPLETEFROM);
+    expectError('SELECT A FROM ', Soql.ErrorType.INCOMPLETEFROM);
   });
 
   it('identify no FROM clause error', () => {
-    expectError('SELECT A', ErrorType.NOFROM);
+    expectError('SELECT A', Soql.ErrorType.NOFROM);
   });
 
   it('identify empty statement error', () => {
-    expectError('', ErrorType.EMPTY);
+    expectError('', Soql.ErrorType.EMPTY);
   });
 
   it('identify incomplete LIMIT clause error when number missing', () => {
-    expectError('SELECT A FROM B LIMIT', ErrorType.INCOMPLETELIMIT);
+    expectError('SELECT A FROM B LIMIT', Soql.ErrorType.INCOMPLETELIMIT);
   });
 
   it('identify incomplete LIMIT clause error when value is not a number', () => {
-    expectError('SELECT A FROM B LIMIT X', ErrorType.INCOMPLETELIMIT);
+    expectError('SELECT A FROM B LIMIT X', Soql.ErrorType.INCOMPLETELIMIT);
   });
 
   it('identify LIMIT 0 as valid limit clause', () => {
@@ -632,60 +632,60 @@ describe('ModelDeserializer should', () => {
   });
 
   it('identify empty WHERE', () => {
-    expectError('SELECT field1 FROM object1 WHERE', ErrorType.EMPTYWHERE);
+    expectError('SELECT field1 FROM object1 WHERE', Soql.ErrorType.EMPTYWHERE);
   });
 
   it('identify incomplete nested WHERE condition', () => {
-    expectError('SELECT field1 FROM object1 WHERE ( field = 5', ErrorType.INCOMPLETENESTEDCONDITION);
+    expectError('SELECT field1 FROM object1 WHERE ( field = 5', Soql.ErrorType.INCOMPLETENESTEDCONDITION);
   });
 
   it('identify incomplete AND/OR condition', () => {
-    expectError('SELECT field1 FROM object1 WHERE field = 5 AND', ErrorType.INCOMPLETEANDORCONDITION);
-    expectError('SELECT field1 FROM object1 WHERE OR field = 5', ErrorType.INCOMPLETEANDORCONDITION);
+    expectError('SELECT field1 FROM object1 WHERE field = 5 AND', Soql.ErrorType.INCOMPLETEANDORCONDITION);
+    expectError('SELECT field1 FROM object1 WHERE OR field = 5', Soql.ErrorType.INCOMPLETEANDORCONDITION);
   });
 
   it('identify incomplete NOT condition', () => {
-    expectError('SELECT field1 FROM object1 WHERE NOT', ErrorType.INCOMPLETENOTCONDITION);
+    expectError('SELECT field1 FROM object1 WHERE NOT', Soql.ErrorType.INCOMPLETENOTCONDITION);
   });
 
   it('identify unrecognized literal value in condition', () => {
-    expectError('SELECT field1 FROM object1 WHERE field = foo', ErrorType.UNRECOGNIZEDCOMPAREVALUE);
-    expectError('SELECT field1 FROM object1 WHERE field LIKE foo', ErrorType.UNRECOGNIZEDCOMPAREVALUE);
-    expectError('SELECT field1 FROM object1 WHERE field IN ( foo )', ErrorType.UNRECOGNIZEDCOMPAREVALUE);
-    expectError('SELECT field1 FROM object1 WHERE field INCLUDES ( foo )', ErrorType.UNRECOGNIZEDCOMPAREVALUE);
+    expectError('SELECT field1 FROM object1 WHERE field = foo', Soql.ErrorType.UNRECOGNIZEDCOMPAREVALUE);
+    expectError('SELECT field1 FROM object1 WHERE field LIKE foo', Soql.ErrorType.UNRECOGNIZEDCOMPAREVALUE);
+    expectError('SELECT field1 FROM object1 WHERE field IN ( foo )', Soql.ErrorType.UNRECOGNIZEDCOMPAREVALUE);
+    expectError('SELECT field1 FROM object1 WHERE field INCLUDES ( foo )', Soql.ErrorType.UNRECOGNIZEDCOMPAREVALUE);
   });
 
   it('identify unrecognized compare operator in condition', () => {
-    expectError('SELECT field1 FROM object1 WHERE field LIK \'foo\'', ErrorType.UNRECOGNIZEDCOMPAREOPERATOR);
+    expectError('SELECT field1 FROM object1 WHERE field LIK \'foo\'', Soql.ErrorType.UNRECOGNIZEDCOMPAREOPERATOR);
   });
 
   it('identify unrecognized compare field in condition', () => {
-    expectError('SELECT field1 FROM object1 WHERE 5 = 5', ErrorType.UNRECOGNIZEDCOMPAREFIELD);
+    expectError('SELECT field1 FROM object1 WHERE 5 = 5', Soql.ErrorType.UNRECOGNIZEDCOMPAREFIELD);
   });
 
   it('identify missing compare value in condition', () => {
-    expectError('SELECT field1 FROM object1 WHERE field =', ErrorType.NOCOMPAREVALUE);
-    expectError('SELECT field1 FROM object1 WHERE field LIKE', ErrorType.NOCOMPAREVALUE);
-    expectError('SELECT field1 FROM object1 WHERE field IN', ErrorType.NOCOMPAREVALUE);
-    expectError('SELECT field1 FROM object1 WHERE field INCLUDES', ErrorType.NOCOMPAREVALUE);
+    expectError('SELECT field1 FROM object1 WHERE field =', Soql.ErrorType.NOCOMPAREVALUE);
+    expectError('SELECT field1 FROM object1 WHERE field LIKE', Soql.ErrorType.NOCOMPAREVALUE);
+    expectError('SELECT field1 FROM object1 WHERE field IN', Soql.ErrorType.NOCOMPAREVALUE);
+    expectError('SELECT field1 FROM object1 WHERE field INCLUDES', Soql.ErrorType.NOCOMPAREVALUE);
   });
 
   it('identify missing compare operator in condition', () => {
-    expectError('SELECT field1 FROM object1 WHERE field', ErrorType.NOCOMPAREOPERATOR);
+    expectError('SELECT field1 FROM object1 WHERE field', Soql.ErrorType.NOCOMPAREOPERATOR);
   });
 
   it('identify incomplete multi-value list', () => {
-    expectError('SELECT field1 FROM object1 WHERE field IN (', ErrorType.INCOMPLETEMULTIVALUELIST);
-    expectError('SELECT field1 FROM object1 WHERE field IN ( \'foo\'', ErrorType.INCOMPLETEMULTIVALUELIST);
-    expectError('SELECT field1 FROM object1 WHERE field IN ( \'foo\',', ErrorType.INCOMPLETEMULTIVALUELIST);
-    expectError('SELECT field1 FROM object1 WHERE field IN ( \'foo\', )', ErrorType.INCOMPLETEMULTIVALUELIST);
-    expectError('SELECT field1 FROM object1 WHERE field INCLUDES (', ErrorType.INCOMPLETEMULTIVALUELIST);
-    expectError('SELECT field1 FROM object1 WHERE field INCLUDES ( \'foo\'', ErrorType.INCOMPLETEMULTIVALUELIST);
-    expectError('SELECT field1 FROM object1 WHERE field INCLUDES ( \'foo\',', ErrorType.INCOMPLETEMULTIVALUELIST);
-    expectError('SELECT field1 FROM object1 WHERE field INCLUDES ( \'foo\', )', ErrorType.INCOMPLETEMULTIVALUELIST);
+    expectError('SELECT field1 FROM object1 WHERE field IN (', Soql.ErrorType.INCOMPLETEMULTIVALUELIST);
+    expectError('SELECT field1 FROM object1 WHERE field IN ( \'foo\'', Soql.ErrorType.INCOMPLETEMULTIVALUELIST);
+    expectError('SELECT field1 FROM object1 WHERE field IN ( \'foo\',', Soql.ErrorType.INCOMPLETEMULTIVALUELIST);
+    expectError('SELECT field1 FROM object1 WHERE field IN ( \'foo\', )', Soql.ErrorType.INCOMPLETEMULTIVALUELIST);
+    expectError('SELECT field1 FROM object1 WHERE field INCLUDES (', Soql.ErrorType.INCOMPLETEMULTIVALUELIST);
+    expectError('SELECT field1 FROM object1 WHERE field INCLUDES ( \'foo\'', Soql.ErrorType.INCOMPLETEMULTIVALUELIST);
+    expectError('SELECT field1 FROM object1 WHERE field INCLUDES ( \'foo\',', Soql.ErrorType.INCOMPLETEMULTIVALUELIST);
+    expectError('SELECT field1 FROM object1 WHERE field INCLUDES ( \'foo\', )', Soql.ErrorType.INCOMPLETEMULTIVALUELIST);
   });
 
-  function expectError(query: string, expectedType: ErrorType): void {
+  function expectError(query: string, expectedType: Soql.ErrorType): void {
     const model = new ModelDeserializer(query).deserialize();
     if (model.errors && model.errors.length === 1) {
       expect(model.errors[0].type).toEqual(expectedType);

--- a/packages/soql-model/src/serialization/deserializer.ts
+++ b/packages/soql-model/src/serialization/deserializer.ts
@@ -382,13 +382,13 @@ class QueryListener implements SoqlParserListener {
       const safeAS = ctx.AS();
       as =
         safeAS !== undefined
-          ? this.toUnmodeledSyntax(safeAS.symbol, idContexts[1].stop as Token, 'unmodeled:as')
-          : this.toUnmodeledSyntax(idContexts[1].start, idContexts[1].stop as Token, 'unmodeled:as');
+          ? this.toUnmodeledSyntax(safeAS.symbol, idContexts[1].stop as Token, Soql.REASON_UNMODELED_AS)
+          : this.toUnmodeledSyntax(idContexts[1].start, idContexts[1].stop as Token, Soql.REASON_UNMODELED_AS);
     }
 
     const safeUSING = ctx.soqlUsingClause();
     const using = safeUSING
-      ? this.toUnmodeledSyntax(safeUSING.start as Token, safeUSING.stop as Token, 'unmodeled:using')
+      ? this.toUnmodeledSyntax(safeUSING.start as Token, safeUSING.stop as Token, Soql.REASON_UNMODELED_USING)
       : undefined;
     this.from = new Impl.FromImpl(sobjectName, as, using);
   }
@@ -425,7 +425,7 @@ class QueryListener implements SoqlParserListener {
           let alias: Soql.UnmodeledSyntax | undefined;
           const aliasCtx = (exprContext as Parser.SoqlSelectColumnExprContext).soqlAlias();
           if (aliasCtx) {
-            alias = this.toUnmodeledSyntax(aliasCtx.start, aliasCtx.stop as Token, 'unmodeled:alias');
+            alias = this.toUnmodeledSyntax(aliasCtx.start, aliasCtx.stop as Token, Soql.REASON_UNMODELED_ALIAS);
           }
           this.selectExpressions.push(new Impl.FieldSelectionImpl(field, alias));
         }
@@ -433,12 +433,12 @@ class QueryListener implements SoqlParserListener {
         // not a modeled case
         const reason =
           exprContext instanceof Parser.SoqlSelectInnerQueryExprContext
-            ? 'unmodeled:semi-join'
+            ? Soql.REASON_UNMODELED_SEMIJOIN
             : exprContext instanceof Parser.SoqlSelectTypeofExprContext
-              ? 'unmodeled:type-of'
+              ? Soql.REASON_UNMODELED_TYPEOF
               : exprContext instanceof Parser.SoqlSelectDistanceExprContext
-                ? 'unmodeled:distance'
-                : 'unmodeled:select';
+                ? Soql.REASON_UNMODELED_DISTANCE
+                : Soql.REASON_UNMODELED_SELECT;
         this.selectExpressions.push(
           this.toUnmodeledSyntax(exprContext.start, exprContext.stop as Token, reason)
         );
@@ -487,7 +487,7 @@ class QueryListener implements SoqlParserListener {
   public enterSoqlWhereClauseMethod(ctx: Parser.SoqlWhereClauseMethodContext): void {
     let condition = this.exprsToCondition(ctx.soqlWhereExprs());
     if (!SoqlModelUtils.isSimpleGroup(condition)) {
-      condition = this.toUnmodeledSyntax(ctx.soqlWhereExprs().start, ctx.soqlWhereExprs().stop as Token, 'unmodeled:complex-group');
+      condition = this.toUnmodeledSyntax(ctx.soqlWhereExprs().start, ctx.soqlWhereExprs().stop as Token, Soql.REASON_UNMODELED_COMPLEXGROUP);
     }
     this.where = new Impl.WhereImpl(condition);
   }
@@ -503,7 +503,7 @@ class QueryListener implements SoqlParserListener {
         this.select = new Impl.SelectExprsImpl(this.selectExpressions);
       } else if (selectCtx instanceof Parser.SoqlSelectCountClauseContext) {
         // not a modeled case
-        this.select = this.toUnmodeledSyntax(selectCtx.start, selectCtx.stop as Token, 'unmodeled:count');
+        this.select = this.toUnmodeledSyntax(selectCtx.start, selectCtx.stop as Token, Soql.REASON_UNMODELED_COUNT);
       } else {
         // no selections
         this.select = new Impl.SelectExprsImpl([]);
@@ -520,11 +520,11 @@ class QueryListener implements SoqlParserListener {
     }
     const withCtx = ctx.soqlWithClause();
     if (withCtx) {
-      this.with = this.toUnmodeledSyntax(withCtx.start, withCtx.stop as Token, 'unmodeled:with');
+      this.with = this.toUnmodeledSyntax(withCtx.start, withCtx.stop as Token, Soql.REASON_UNMODELED_WITH);
     }
     const groupByCtx = ctx.soqlGroupByClause();
     if (groupByCtx) {
-      this.groupBy = this.toUnmodeledSyntax(groupByCtx.start, groupByCtx.stop as Token, 'unmodeled:group-by');
+      this.groupBy = this.toUnmodeledSyntax(groupByCtx.start, groupByCtx.stop as Token, Soql.REASON_UNMODELED_GROUPBY);
     }
     const orderByCtx = ctx.soqlOrderByClause();
     if (orderByCtx) {
@@ -536,23 +536,23 @@ class QueryListener implements SoqlParserListener {
     }
     const offsetCtx = ctx.soqlOffsetClause();
     if (offsetCtx) {
-      this.offset = this.toUnmodeledSyntax(offsetCtx.start, offsetCtx.stop as Token, 'unmodeled:offset');
+      this.offset = this.toUnmodeledSyntax(offsetCtx.start, offsetCtx.stop as Token, Soql.REASON_UNMODELED_OFFSET);
     }
     const bindCtx = ctx.soqlBindClause();
     if (bindCtx) {
-      this.bind = this.toUnmodeledSyntax(bindCtx.start, bindCtx.stop as Token, 'unmodeled:bind');
+      this.bind = this.toUnmodeledSyntax(bindCtx.start, bindCtx.stop as Token, Soql.REASON_UNMODELED_BIND);
     }
     const recordTrackingTypeCtx = ctx.soqlRecordTrackingType();
     if (recordTrackingTypeCtx) {
       this.recordTrackingType = this.toUnmodeledSyntax(
         recordTrackingTypeCtx.start,
         recordTrackingTypeCtx.stop as Token,
-        'unmodeled:record-tracking'
+        Soql.REASON_UNMODELED_RECORDTRACKING
       );
     }
     const updateCtx = ctx.soqlUpdateStatsClause();
     if (updateCtx) {
-      this.update = this.toUnmodeledSyntax(updateCtx.start, updateCtx.stop as Token, 'unmodeled:update');
+      this.update = this.toUnmodeledSyntax(updateCtx.start, updateCtx.stop as Token, Soql.REASON_UNMODELED_UPDATE);
     }
   }
 
@@ -578,7 +578,7 @@ class QueryListener implements SoqlParserListener {
     return this.query;
   }
 
-  public toUnmodeledSyntax(start: Token, stop: Token, reason: string): Soql.UnmodeledSyntax {
+  public toUnmodeledSyntax(start: Token, stop: Token, reason: Soql.UnmodeledSyntaxReason): Soql.UnmodeledSyntax {
     if (!stop && start) {
       // some error states can cause this situation
       stop = start;
@@ -600,7 +600,7 @@ class QueryListener implements SoqlParserListener {
       const fieldCtx = (ctx as Parser.SoqlOrderByColumnExprContext).soqlField();
       result = this.toField(fieldCtx);
     } else {
-      result = this.toUnmodeledSyntax(ctx.start, ctx.stop as Token, 'unmodeled:distance');
+      result = this.toUnmodeledSyntax(ctx.start, ctx.stop as Token, Soql.REASON_UNMODELED_DISTANCE);
     }
 
     return result;
@@ -610,7 +610,7 @@ class QueryListener implements SoqlParserListener {
     let result: Soql.Field;
     const isFunctionRef = ctx.text.includes('(');
     if (isFunctionRef) {
-      result = this.toUnmodeledSyntax(ctx.start, ctx.stop as Token, 'unmodeled:function-reference');
+      result = this.toUnmodeledSyntax(ctx.start, ctx.stop as Token, Soql.REASON_UNMODELED_FUNCTIONREFERENCE);
     } else {
       result = new Impl.FieldRefImpl(ctx.text);
     }
@@ -664,9 +664,9 @@ class QueryListener implements SoqlParserListener {
 
   protected toCompareValue(ctx: ParserRuleContext): Soql.CompareValue {
     if (ctx instanceof Parser.SoqlColonExprLiteralValueContext) {
-      return this.toUnmodeledSyntax(ctx.start, ctx.stop as Token, 'unmodeled:colon-expression');
+      return this.toUnmodeledSyntax(ctx.start, ctx.stop as Token, Soql.REASON_UNMODELED_COLONEXPRESSION);
     } else if (ctx instanceof Parser.SoqlColonLikeValueContext) {
-      return this.toUnmodeledSyntax(ctx.start, ctx.stop as Token, 'unmodeled:colon-expression');
+      return this.toUnmodeledSyntax(ctx.start, ctx.stop as Token, Soql.REASON_UNMODELED_COLONEXPRESSION);
     }
     return this.toLiteral(ctx);
   }
@@ -754,13 +754,13 @@ class QueryListener implements SoqlParserListener {
       );
     } else {
       // empty clause
-      condition = new Impl.UnmodeledSyntaxImpl('', 'unmodeled:empty-condition');
+      condition = new Impl.UnmodeledSyntaxImpl('', Soql.REASON_UNMODELED_EMPTYCONDITION);
     }
     return condition;
   }
 
   protected exprToCondition(ctx: Parser.SoqlWhereExprContext): Soql.Condition {
-    let reason = 'unmodeled:empty-condition';
+    let reason = Soql.REASON_UNMODELED_EMPTYCONDITION;
     if (ctx instanceof Parser.NestedWhereExprContext) {
       const nested = this.exprsToCondition(ctx.soqlWhereExprs());
       return new Impl.NestedConditionImpl(nested);
@@ -791,13 +791,13 @@ class QueryListener implements SoqlParserListener {
       const values = this.toCompareValues(ctx.tryGetRuleContext(0, Parser.SoqlLiteralValuesContext));
       return new Impl.InListConditionImpl(field, operator, values);
     } else if (ctx instanceof Parser.CalculatedWhereExprContext) {
-      reason = 'unmodeled:calculated-condition';
+      reason = Soql.REASON_UNMODELED_CALCULATEDCONDITION;
     } else if (ctx instanceof Parser.DistanceWhereExprContext) {
-      reason = 'unmodeled:distance-condition';
+      reason = Soql.REASON_UNMODELED_DISTANCECONDITION;
     } else if (ctx instanceof Parser.InWhereExprForColonExprContext) {
-      reason = 'unmodeled:in-colon-expression-condition';
+      reason = Soql.REASON_UNMODELED_INCOLONEXPRESSIONCONDITION;
     } else if (ctx instanceof Parser.InWhereExprWithSemiJoinContext) {
-      reason = 'unmodeled:in-semi-join-condition';
+      reason = Soql.REASON_UNMODELED_INSEMIJOINCONDITION;
     }
     return this.toUnmodeledSyntax(ctx.start, ctx.stop as Token, reason);
   }


### PR DESCRIPTION
### What does this PR do?
This PR creates human readable messages for unsupported syntax. The existing 'reason codes', formatted like `unmodeled:<soql element>`, are retained for telemetry purposes.

### What issues does this PR fix or reference?
@W-8793969@