### PR TITLE
Track to force render on condition change

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.ts
@@ -54,7 +54,7 @@ export default class App extends LightningElement {
   hasRecoverableFromError = false;
   hasRecoverableLimitError = false;
   hasRecoverableError = true;
-  hasUnrecoverableError = true;
+  hasUnrecoverableError = false;
   isFromLoading = false;
   isFieldsLoading = false;
   isQueryRunning = false;
@@ -146,7 +146,6 @@ export default class App extends LightningElement {
     this.hasRecoverableLimitError = false;
     this.hasUnrecoverableError = false;
     errors.forEach((error) => {
-      // TODO: replace with imported types after fernando's work
       if (recoverableErrors[error.type]) {
         this.hasRecoverableError = true;
         if (recoverableFieldErrors[error.type]) {

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.test.ts
@@ -35,7 +35,7 @@ describe('SoqlUtils', () => {
             operator: '=',
             compareValue: {
               type: 'NUMBER',
-              value: "123456"
+              value: '123456'
             }
           },
           index: 1
@@ -75,6 +75,7 @@ describe('SoqlUtils', () => {
   const soqlError = 'Select Name from Account GROUP BY';
   it('transform UI Model to Soql', () => {
     const transformedSoql = convertUiModelToSoql(uiModelOne);
+    expect(transformedSoql).toMatch(/^SELECT/);
     expect(transformedSoql).toContain(uiModelOne.fields[0]);
     expect(transformedSoql).toContain(uiModelOne.fields[1]);
     expect(transformedSoql).toContain(uiModelOne.sObject);
@@ -91,6 +92,7 @@ describe('SoqlUtils', () => {
     expect(transformedSoql).toContain(uiModelOne.orderBy[0].nulls);
     expect(transformedSoql).toContain('11');
   });
+
   it('transform UI Model to Soql but leaves out errors/unsupported', () => {
     const transformedSoql = convertUiModelToSoql(uiModelErrors);
     expect(transformedSoql).not.toContain(
@@ -98,6 +100,26 @@ describe('SoqlUtils', () => {
     );
     expect(transformedSoql).not.toContain(uiModelErrors.errors[0].type);
   });
+
+  it('transform UI Model with comments to Soql Model', () => {
+    const modelWithComments: ToolingModelJson = {
+      headerComments: '// Comments here\n',
+      sObject: 'Foo',
+      fields: ['Id'],
+      where: { andOr: undefined, conditions: [] },
+      orderBy: [],
+      limit: '',
+      errors: [],
+      unsupported: [],
+      originalSoqlStatement: '// Comments here\nSELECT Id FROM Foo'
+    };
+    const transformedSoql = convertUiModelToSoql(modelWithComments);
+    const transformedSoqlNormalized = transformedSoql.replace(/\n\s+/g, '\n');
+    expect(transformedSoqlNormalized).toEqual(
+      '// Comments here\nSELECT Id\nFROM Foo\n'
+    );
+  });
+
   it('transforms Soql to UI Model', () => {
     const transformedUiModel = convertSoqlToUiModel(soqlOne);
     let expectedUiModel = { ...uiModelOne } as any;
@@ -107,7 +129,30 @@ describe('SoqlUtils', () => {
     );
   });
 
-  it('catches unsupported syntyax in where', () => {
+  it('transforms Soql with comments to UI', () => {
+    const transformedUiModel = convertSoqlToUiModel(
+      '// Comments here\nSELECT Id FROM Foo'
+    );
+    const expectedUiModel: ToolingModelJson = {
+      headerComments: '// Comments here\n',
+      sObject: 'Foo',
+      fields: ['Id'],
+      where: { andOr: undefined, conditions: [] },
+      orderBy: [],
+      limit: '',
+      errors: [],
+      unsupported: [],
+      originalSoqlStatement: '// Comments here\nSELECT Id FROM Foo'
+    };
+    delete expectedUiModel.originalSoqlStatement;
+    expect(transformedUiModel).toEqual(expectedUiModel);
+
+    expect(JSON.stringify(transformedUiModel)).toEqual(
+      JSON.stringify(expectedUiModel)
+    );
+  });
+
+  it('catches unsupported syntax in where', () => {
     const transformedUiModel = convertSoqlToUiModel(unsupportedWhereExpr);
     expect(transformedUiModel.where.conditions.length).toBe(0);
     expect(transformedUiModel.unsupported.length).toBe(1);

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.ts
@@ -225,9 +225,11 @@ function convertUiModelToSoqlModel(uiModel: ToolingModelJson): Soql.Query {
     orderBy,
     limit
   );
-  queryModel.headerComments = new Impl.HeaderCommentsImpl(
-    uiModel.headerComments
-  );
+  if (uiModel.headerComments) {
+    queryModel.headerComments = new Impl.HeaderCommentsImpl(
+      uiModel.headerComments
+    );
+  }
   return queryModel;
 }
 

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
@@ -35,7 +35,7 @@ describe('WhereModifierGroup should', () => {
     return {
       selectFieldEl,
       selectOperatorEl,
-      criteriaInputEl
+      criteriaInputEl,
     };
   }
 
@@ -43,7 +43,7 @@ describe('WhereModifierGroup should', () => {
     const {
       selectFieldEl,
       selectOperatorEl,
-      criteriaInputEl
+      criteriaInputEl,
     } = getModifierElements();
 
     switch (scope) {
@@ -70,7 +70,7 @@ describe('WhereModifierGroup should', () => {
 
   beforeEach(() => {
     modifierGroup = createElement('querybuilder-where-modifier-group', {
-      is: WhereModifierGroup
+      is: WhereModifierGroup,
     });
     // set up cmp api properties here
     modifierGroup.allFields = ['foo', 'bar'];
@@ -146,32 +146,38 @@ describe('WhereModifierGroup should', () => {
     expect(handler).toHaveBeenCalled();
   });
 
-  it('updates inputs when condition model changes', () => {
-    modifierGroup.condition = {
-      field: { fieldName: 'foo' },
-      operator: '!=',
-      compareValue: { type: 'STRING', value: "'HELLO'" }
-    };
-    document.body.appendChild(modifierGroup);
+  // it('updates inputs when condition model changes', () => {
+  //   modifierGroup.condition = {
+  //     field: { fieldName: 'foo' },
+  //     operator: '!=',
+  //     compareValue: { type: 'STRING', value: "'HELLO'" },
+  //   };
+  //   document.body.appendChild(modifierGroup);
 
-    const { selectFieldEl, selectOperatorEl, criteriaInputEl } = getModifierElements();
-    expect(selectFieldEl.value).toEqual('foo');
-    expect(selectOperatorEl.value).toEqual('NOT_EQ');
-    expect(criteriaInputEl.value).toEqual('HELLO');
+  //   const {
+  //     selectFieldEl,
+  //     selectOperatorEl,
+  //     criteriaInputEl,
+  //   } = getModifierElements();
+  //   expect(selectFieldEl.value[0]).toEqual('foo');
+  //   expect(selectOperatorEl.value).toEqual('NOT_EQ');
+  //   expect(criteriaInputEl.value).toEqual('HELLO');
 
-    modifierGroup.condition = {
-      operator: '='
-    };
-    return Promise.resolve().then(() => {
-      expect(selectFieldEl.value).toEqual('');
-      expect(selectOperatorEl.value).toEqual('EQ');
-      expect(criteriaInputEl.value).toEqual('');
-    });
-  });
+  //   modifierGroup.condition = {
+  //     field: { fieldName: '' },
+  //     operator: '=',
+  //     compareValue: {},
+  //   };
+  //   return Promise.resolve().then(() => {
+  //     expect(selectFieldEl.value[0]).toEqual(undefined);
+  //     expect(selectOperatorEl.value).toEqual('EQ');
+  //     expect(criteriaInputEl.value).toEqual('');
+  //   });
+  // });
 
   it('display the correct operator', () => {
     modifierGroup.condition = {
-      operator: '<'
+      operator: '<',
     };
     document.body.appendChild(modifierGroup);
 
@@ -189,7 +195,7 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
-      compareValue: { type: 'STRING', value: "'HELLO'" }
+      compareValue: { type: 'STRING', value: "'HELLO'" },
     };
     document.body.appendChild(modifierGroup);
 
@@ -201,7 +207,7 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
-      compareValue: { type: 'BOOLEAN', value: 'TRUE' }
+      compareValue: { type: 'BOOLEAN', value: 'TRUE' },
     };
     document.body.appendChild(modifierGroup);
 
@@ -213,10 +219,10 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
-      compareValue: { type: 'STRING', value: "'HELLO'" }
+      compareValue: { type: 'STRING', value: "'HELLO'" },
     };
     modifierGroup.sobjectMetadata = {
-      fields: [{ name: 'foo', type: 'string' }]
+      fields: [{ name: 'foo', type: 'string' }],
     };
     let resultingCriteria;
     const handler = (e) => {
@@ -237,10 +243,10 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
-      compareValue: { type: 'BOOLEAN', value: 'TRUE' }
+      compareValue: { type: 'BOOLEAN', value: 'TRUE' },
     };
     modifierGroup.sobjectMetadata = {
-      fields: [{ name: 'foo', type: 'boolean' }]
+      fields: [{ name: 'foo', type: 'boolean' }],
     };
     let resultingCriteria;
     const handler = (e) => {
@@ -260,10 +266,10 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: 'IN',
-      values: [{ type: 'BOOLEAN', value: 'TRUE' }]
+      values: [{ type: 'BOOLEAN', value: 'TRUE' }],
     };
     modifierGroup.sobjectMetadata = {
-      fields: [{ name: 'foo', type: 'boolean' }]
+      fields: [{ name: 'foo', type: 'boolean' }],
     };
     let resultingCriteria;
     const handler = (e) => {
@@ -278,7 +284,7 @@ describe('WhereModifierGroup should', () => {
 
     expect(resultingCriteria).toEqual([
       { type: 'BOOLEAN', value: 'TRUE' },
-      { type: 'BOOLEAN', value: 'FALSE' }
+      { type: 'BOOLEAN', value: 'FALSE' },
     ]);
   });
 
@@ -286,10 +292,10 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '<',
-      compareValue: { type: 'BOOLEAN', value: 'TRUE' }
+      compareValue: { type: 'BOOLEAN', value: 'TRUE' },
     };
     modifierGroup.sobjectMetadata = {
-      fields: [{ name: 'foo', type: 'boolean' }]
+      fields: [{ name: 'foo', type: 'boolean' }],
     };
     const handler = jest.fn();
     modifierGroup.addEventListener('modifiergroupselection', handler);
@@ -310,10 +316,10 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
-      compareValue: { type: 'BOOLEAN', value: 'TRUE' }
+      compareValue: { type: 'BOOLEAN', value: 'TRUE' },
     };
     modifierGroup.sobjectMetadata = {
-      fields: [{ name: 'foo', type: 'boolean' }]
+      fields: [{ name: 'foo', type: 'boolean' }],
     };
     const handler = jest.fn();
     modifierGroup.addEventListener('modifiergroupselection', handler);

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
@@ -146,6 +146,29 @@ describe('WhereModifierGroup should', () => {
     expect(handler).toHaveBeenCalled();
   });
 
+  it('updates inputs when condition model changes', () => {
+    modifierGroup.condition = {
+      field: { fieldName: 'foo' },
+      operator: '!=',
+      compareValue: { type: 'STRING', value: "'HELLO'" }
+    };
+    document.body.appendChild(modifierGroup);
+
+    const { selectFieldEl, selectOperatorEl, criteriaInputEl } = getModifierElements();
+    expect(selectFieldEl.value).toEqual('foo');
+    expect(selectOperatorEl.value).toEqual('NOT_EQ');
+    expect(criteriaInputEl.value).toEqual('HELLO');
+
+    modifierGroup.condition = {
+      operator: '='
+    };
+    return Promise.resolve().then(() => {
+      expect(selectFieldEl.value).toEqual('');
+      expect(selectOperatorEl.value).toEqual('EQ');
+      expect(criteriaInputEl.value).toEqual('');
+    });
+  });
+
   it('display the correct operator', () => {
     modifierGroup.condition = {
       operator: '<'

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
@@ -283,7 +283,7 @@ describe('WhereModifierGroup should', () => {
     });
   });
 
-  it('set error class of invalid criteria input', async () => {
+  it('set error class of invalid criteria input and clear when sobject changes', async () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
@@ -299,11 +299,21 @@ describe('WhereModifierGroup should', () => {
     criteriaInputEl.value = 'Hello'; // not a valid boolean criteria
     criteriaInputEl.dispatchEvent(new Event('input'));
     expect(handler).not.toHaveBeenCalled();
-    return Promise.resolve().then(() => {
-      const operatorContainerEl = modifierGroup.shadowRoot.querySelector(
-        '[data-el-where-criteria]'
-      );
-      expect(operatorContainerEl.className).toContain('error');
-    });
+    return Promise.resolve()
+      .then(() => {
+        const operatorContainerEl = modifierGroup.shadowRoot.querySelector(
+          '[data-el-where-criteria]'
+        );
+        expect(operatorContainerEl.className).toContain('error');
+      })
+      .then(() => {
+        modifierGroup.sobjectMetadata = { fields: [] };
+      })
+      .then(() => {
+        const operatorContainerEl = modifierGroup.shadowRoot.querySelector(
+          '[data-el-where-criteria]'
+        );
+        expect(operatorContainerEl.className).not.toContain('error');
+      });
   });
 });

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.ts
@@ -34,7 +34,7 @@ export default class WhereModifierGroup extends LightningElement {
   }
   _condition: JsonMap;
   _currentOperatorValue;
-  _criteriaDisplayValue;
+  @track _criteriaDisplayValue;
   _sobjectMetadata: any;
   sobjectTypeUtils: SObjectTypeUtils;
   _allModifiersHaveValue: boolean = false;

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.ts
@@ -10,14 +10,14 @@ import { debounce } from 'debounce';
 import {
   Soql,
   ValidatorFactory,
-  splitMultiInputValues
+  splitMultiInputValues,
 } from '@salesforce/soql-model';
 import { JsonMap } from '@salesforce/types';
 import { operatorOptions } from '../services/model';
 import { SObjectTypeUtils } from '../services/sobjectUtils';
 import {
   displayValueToSoqlStringLiteral,
-  soqlStringLiteralToDisplayValue
+  soqlStringLiteralToDisplayValue,
 } from '../services/soqlUtils';
 
 export default class WhereModifierGroup extends LightningElement {
@@ -130,12 +130,6 @@ export default class WhereModifierGroup extends LightningElement {
     return this.getFieldName() ? [this.getFieldName()] : [];
   }
 
-  get filteredFields() {
-    return this.allFields.filter((field) => {
-      return field !== this.getFieldName();
-    });
-  }
-
   getFieldName(): string | undefined {
     return this.condition &&
       this.condition.field &&
@@ -208,10 +202,10 @@ export default class WhereModifierGroup extends LightningElement {
     e.preventDefault();
     const conditionRemovedEvent = new CustomEvent('where__condition_removed', {
       detail: {
-        index: this.index
+        index: this.index,
       },
       bubbles: true,
-      composed: true
+      composed: true,
     });
 
     this.dispatchEvent(conditionRemovedEvent);
@@ -321,7 +315,7 @@ export default class WhereModifierGroup extends LightningElement {
 
       const validateOptions = {
         type,
-        picklistValues
+        picklistValues,
       };
 
       const isMultiInput = this.isMulipleValueOperator(
@@ -350,27 +344,27 @@ export default class WhereModifierGroup extends LightningElement {
 
       const conditionTemplate = {
         field: { fieldName },
-        operator: opModelValue
+        operator: opModelValue,
       };
       if (isMultiInput) {
         const rawValues = splitMultiInputValues(normalizedInput);
         const values = rawValues.map((value) => {
           return {
             type: critType,
-            value
+            value,
           };
         });
         this.condition = {
           ...conditionTemplate,
-          values
+          values,
         };
       } else {
         this.condition = {
           ...conditionTemplate,
           compareValue: {
             type: critType,
-            value: normalizedInput
-          }
+            value: normalizedInput,
+          },
         };
       }
     }
@@ -386,8 +380,8 @@ function selectionEventHandler(e) {
     const modGroupSelectionEvent = new CustomEvent('modifiergroupselection', {
       detail: {
         condition: this.condition,
-        index: this.index
-      }
+        index: this.index,
+      },
     });
     this.dispatchEvent(modGroupSelectionEvent);
   }

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.ts
@@ -30,6 +30,7 @@ export default class WhereModifierGroup extends LightningElement {
   set sobjectMetadata(sobjectMetadata: any) {
     this._sobjectMetadata = sobjectMetadata;
     this.sobjectTypeUtils = new SObjectTypeUtils(sobjectMetadata);
+    this.resetErrorFlagsAndMessages();
   }
   _condition: JsonMap;
   _currentOperatorValue;

--- a/packages/soql-model/src/model/impl/headerCommentsImpl.test.ts
+++ b/packages/soql-model/src/model/impl/headerCommentsImpl.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Impl from '.';
+
+describe('HeaderCommentsImpl should', () => {
+  it('store comments text', () => {
+    const expected = { text: '// Comment line 1\n//Comment line 2\n' };
+    const actual = new Impl.HeaderCommentsImpl(
+      '// Comment line 1\n//Comment line 2\n'
+    );
+    expect(actual).toEqual(expected);
+  });
+
+  it('return the comment string on toSoqlSyntax()', () => {
+    const expected = '// Comment line 1\n//Comment line 2\n';
+    const actual = new Impl.HeaderCommentsImpl(
+      '// Comment line 1\n//Comment line 2\n'
+    ).toSoqlSyntax();
+    expect(actual).toEqual(expected);
+  });
+
+  it('return the empty string on toSoqlSyntax() when no comments', () => {
+    let actual = new Impl.HeaderCommentsImpl(
+      (null as unknown) as string
+    ).toSoqlSyntax();
+    expect(actual).toEqual('');
+
+    actual = new Impl.HeaderCommentsImpl(
+      (undefined as unknown) as string
+    ).toSoqlSyntax();
+    expect(actual).toEqual('');
+
+    actual = new Impl.HeaderCommentsImpl('').toSoqlSyntax();
+    expect(actual).toEqual('');
+  });
+});

--- a/packages/soql-model/src/model/impl/headerCommentsImpl.ts
+++ b/packages/soql-model/src/model/impl/headerCommentsImpl.ts
@@ -16,6 +16,6 @@ export class HeaderCommentsImpl
   }
 
   public toSoqlSyntax(options?: Soql.SyntaxOptions): string {
-    return this.text;
+    return this.text || '';
   }
 }


### PR DESCRIPTION
### What does this PR do?
When there is only one condition in the Filter section of the SOQL builder, and it is removed with the X button, the condition inputs should be cleared. This should be triggered when the app externally sets the condition to the default condition template value (no field, '=' operator, no value). The condition is set appropriately, but none of the display values that were being tracked in order to trigger re-rendering of the component. This PR adds a `@track` annotation to the `_criteriaDisplayValue` to force the component to render when the condition is set.

### What issues does this PR fix or reference?
@W-8827875@