### PR TITLE
Clear tooltip when object changes, fix empty soql statement error blocker

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.ts
@@ -54,7 +54,7 @@ export default class App extends LightningElement {
   hasRecoverableFromError = false;
   hasRecoverableLimitError = false;
   hasRecoverableError = true;
-  hasUnrecoverableError = true;
+  hasUnrecoverableError = false;
   isFromLoading = false;
   isFieldsLoading = false;
   isQueryRunning = false;
@@ -146,7 +146,6 @@ export default class App extends LightningElement {
     this.hasRecoverableLimitError = false;
     this.hasUnrecoverableError = false;
     errors.forEach((error) => {
-      // TODO: replace with imported types after fernando's work
       if (recoverableErrors[error.type]) {
         this.hasRecoverableError = true;
         if (recoverableFieldErrors[error.type]) {

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
@@ -283,7 +283,7 @@ describe('WhereModifierGroup should', () => {
     });
   });
 
-  it('set error class of invalid criteria input', async () => {
+  it('set error class of invalid criteria input and clear when sobject changes', async () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
@@ -299,11 +299,21 @@ describe('WhereModifierGroup should', () => {
     criteriaInputEl.value = 'Hello'; // not a valid boolean criteria
     criteriaInputEl.dispatchEvent(new Event('input'));
     expect(handler).not.toHaveBeenCalled();
-    return Promise.resolve().then(() => {
-      const operatorContainerEl = modifierGroup.shadowRoot.querySelector(
-        '[data-el-where-criteria]'
-      );
-      expect(operatorContainerEl.className).toContain('error');
-    });
+    return Promise.resolve()
+      .then(() => {
+        const operatorContainerEl = modifierGroup.shadowRoot.querySelector(
+          '[data-el-where-criteria]'
+        );
+        expect(operatorContainerEl.className).toContain('error');
+      })
+      .then(() => {
+        modifierGroup.sobjectMetadata = { fields: [] };
+      })
+      .then(() => {
+        const operatorContainerEl = modifierGroup.shadowRoot.querySelector(
+          '[data-el-where-criteria]'
+        );
+        expect(operatorContainerEl.className).not.toContain('error');
+      });
   });
 });

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.ts
@@ -30,6 +30,7 @@ export default class WhereModifierGroup extends LightningElement {
   set sobjectMetadata(sobjectMetadata: any) {
     this._sobjectMetadata = sobjectMetadata;
     this.sobjectTypeUtils = new SObjectTypeUtils(sobjectMetadata);
+    this.resetErrorFlagsAndMessages();
   }
   _condition: JsonMap;
   _currentOperatorValue;


### PR DESCRIPTION
### What does this PR do?

This fixes 2 bugs.
1. The error that blocks the soql builder if the soql query is empty
2. The error tooltips do not clear when sobject is changed.

### What issues does this PR fix or reference?
@W-8827780@

https://user-images.githubusercontent.com/599418/106809798-5757db80-6629-11eb-9bd4-f3d376307691.mov




https://user-images.githubusercontent.com/599418/106809781-532bbe00-6629-11eb-91ad-f1fb07564a01.mov


