### PR TITLE
remove check for selectedOptions.length, fix test

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.ts
@@ -48,7 +48,7 @@ export default class CustomSelect extends LightningElement {
 
   set selectedOptions(selectedOptions: string[]) {
     this._selectedOptions = selectedOptions || [];
-    if (selectedOptions && selectedOptions.length) {
+    if (selectedOptions) {
       this._value = selectedOptions;
     }
   }
@@ -192,8 +192,8 @@ export default class CustomSelect extends LightningElement {
       const optionValue = validOptionMatch[0];
       const optionSelectionEvent = new CustomEvent('option__selection', {
         detail: {
-          value: optionValue
-        }
+          value: optionValue,
+        },
       });
 
       if (this.isSingleSelect) {
@@ -228,7 +228,7 @@ export default class CustomSelect extends LightningElement {
       this.optionList[position].classList.add('option--highlight');
       this.optionList[position].scrollIntoView({
         block: 'end',
-        inline: 'nearest'
+        inline: 'nearest',
       });
     }
   }
@@ -280,7 +280,7 @@ export default class CustomSelect extends LightningElement {
     const optionsOpenedEvent = new CustomEvent(this.customSelectEventName, {
       detail: { target: e.target },
       bubbles: true,
-      composed: true
+      composed: true,
     }) as CustomSelectEvent;
 
     this.dispatchEvent(optionsOpenedEvent);

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
@@ -35,7 +35,7 @@ describe('WhereModifierGroup should', () => {
     return {
       selectFieldEl,
       selectOperatorEl,
-      criteriaInputEl
+      criteriaInputEl,
     };
   }
 
@@ -43,7 +43,7 @@ describe('WhereModifierGroup should', () => {
     const {
       selectFieldEl,
       selectOperatorEl,
-      criteriaInputEl
+      criteriaInputEl,
     } = getModifierElements();
 
     switch (scope) {
@@ -70,7 +70,7 @@ describe('WhereModifierGroup should', () => {
 
   beforeEach(() => {
     modifierGroup = createElement('querybuilder-where-modifier-group', {
-      is: WhereModifierGroup
+      is: WhereModifierGroup,
     });
     // set up cmp api properties here
     modifierGroup.allFields = ['foo', 'bar'];
@@ -146,28 +146,28 @@ describe('WhereModifierGroup should', () => {
     expect(handler).toHaveBeenCalled();
   });
 
-  it.skip('updates inputs when condition model changes', () => {
+  it('updates inputs when condition model changes', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '!=',
-      compareValue: { type: 'STRING', value: "'HELLO'" }
+      compareValue: { type: 'STRING', value: "'HELLO'" },
     };
     document.body.appendChild(modifierGroup);
 
     const {
       selectFieldEl,
       selectOperatorEl,
-      criteriaInputEl
+      criteriaInputEl,
     } = getModifierElements();
-    expect(selectFieldEl.value).toEqual('foo');
+    expect(selectFieldEl.value[0]).toEqual('foo');
     expect(selectOperatorEl.value).toEqual('NOT_EQ');
     expect(criteriaInputEl.value).toEqual('HELLO');
 
     modifierGroup.condition = {
-      operator: '='
+      operator: '=',
     };
     return Promise.resolve().then(() => {
-      expect(selectFieldEl.value).toEqual('');
+      expect(selectFieldEl.value).toEqual([]);
       expect(selectOperatorEl.value).toEqual('EQ');
       expect(criteriaInputEl.value).toEqual('');
     });
@@ -175,7 +175,7 @@ describe('WhereModifierGroup should', () => {
 
   it('display the correct operator', () => {
     modifierGroup.condition = {
-      operator: '<'
+      operator: '<',
     };
     document.body.appendChild(modifierGroup);
 
@@ -193,7 +193,7 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
-      compareValue: { type: 'STRING', value: "'HELLO'" }
+      compareValue: { type: 'STRING', value: "'HELLO'" },
     };
     document.body.appendChild(modifierGroup);
 
@@ -205,7 +205,7 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
-      compareValue: { type: 'BOOLEAN', value: 'TRUE' }
+      compareValue: { type: 'BOOLEAN', value: 'TRUE' },
     };
     document.body.appendChild(modifierGroup);
 
@@ -217,10 +217,10 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
-      compareValue: { type: 'STRING', value: "'HELLO'" }
+      compareValue: { type: 'STRING', value: "'HELLO'" },
     };
     modifierGroup.sobjectMetadata = {
-      fields: [{ name: 'foo', type: 'string' }]
+      fields: [{ name: 'foo', type: 'string' }],
     };
     let resultingCriteria;
     const handler = (e) => {
@@ -241,10 +241,10 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
-      compareValue: { type: 'BOOLEAN', value: 'TRUE' }
+      compareValue: { type: 'BOOLEAN', value: 'TRUE' },
     };
     modifierGroup.sobjectMetadata = {
-      fields: [{ name: 'foo', type: 'boolean' }]
+      fields: [{ name: 'foo', type: 'boolean' }],
     };
     let resultingCriteria;
     const handler = (e) => {
@@ -264,10 +264,10 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: 'IN',
-      values: [{ type: 'BOOLEAN', value: 'TRUE' }]
+      values: [{ type: 'BOOLEAN', value: 'TRUE' }],
     };
     modifierGroup.sobjectMetadata = {
-      fields: [{ name: 'foo', type: 'boolean' }]
+      fields: [{ name: 'foo', type: 'boolean' }],
     };
     let resultingCriteria;
     const handler = (e) => {
@@ -282,7 +282,7 @@ describe('WhereModifierGroup should', () => {
 
     expect(resultingCriteria).toEqual([
       { type: 'BOOLEAN', value: 'TRUE' },
-      { type: 'BOOLEAN', value: 'FALSE' }
+      { type: 'BOOLEAN', value: 'FALSE' },
     ]);
   });
 
@@ -290,10 +290,10 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '<',
-      compareValue: { type: 'BOOLEAN', value: 'TRUE' }
+      compareValue: { type: 'BOOLEAN', value: 'TRUE' },
     };
     modifierGroup.sobjectMetadata = {
-      fields: [{ name: 'foo', type: 'boolean' }]
+      fields: [{ name: 'foo', type: 'boolean' }],
     };
     const handler = jest.fn();
     modifierGroup.addEventListener('modifiergroupselection', handler);
@@ -314,10 +314,10 @@ describe('WhereModifierGroup should', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
       operator: '=',
-      compareValue: { type: 'BOOLEAN', value: 'TRUE' }
+      compareValue: { type: 'BOOLEAN', value: 'TRUE' },
     };
     modifierGroup.sobjectMetadata = {
-      fields: [{ name: 'foo', type: 'boolean' }]
+      fields: [{ name: 'foo', type: 'boolean' }],
     };
     const handler = jest.fn();
     modifierGroup.addEventListener('modifiergroupselection', handler);


### PR DESCRIPTION
### What does this PR do?

This PR will address a bug where the field of the last modifier group would not be cleared because the customSelect component would not update the `_value` with an empty array coming from the model.

I have also refactored a skipped test to work with the customSelect.

### What issues does this PR fix or reference?
@W-8847700@