### PR TITLE
Select COUNT()

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.html
@@ -29,7 +29,6 @@
           selected-fields={query.fields}
           fields={fields}
           onfields__selected={handleFieldSelected}
-          onfields__removed={handleFieldRemoved}
           has-error={hasRecoverableFieldsError}
           is-loading={isFieldsLoading}
           class={theme}

--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.ts
@@ -179,12 +179,9 @@ export default class App extends LightningElement {
   }
   /* ---- FIELD HANDLERS ---- */
   handleFieldSelected(e) {
-    this.modelService.addField(e.detail.field);
+    this.modelService.setFields(e.detail.fields);
   }
 
-  handleFieldRemoved(e) {
-    this.modelService.removeField(e.detail.field);
-  }
   /* ---- ORDER BY HANDLERS ---- */
   handleOrderBySelected(e) {
     this.modelService.addUpdateOrderByField(e.detail);

--- a/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.test.ts
@@ -57,7 +57,7 @@ describe('Fields', () => {
     expect(handler).toHaveBeenCalled();
   });
 
-  it('renders the selected fields in the component', () => {
+  it('renders COUNT() and the selected fields in the component', () => {
     document.body.appendChild(fields);
 
     let selectedFieldEl = fields.shadowRoot.querySelectorAll('.selected-field');
@@ -68,7 +68,7 @@ describe('Fields', () => {
 
     return Promise.resolve().then(() => {
       selectedFieldEl = fields.shadowRoot.querySelectorAll('.selected-field');
-      expect(selectedFieldEl.length).toBe(3);
+      expect(selectedFieldEl.length).toBe(4);
     });
   });
 
@@ -85,5 +85,45 @@ describe('Fields', () => {
       hasError = fields.shadowRoot.querySelectorAll('[data-el-has-error]');
       expect(hasError.length).toEqual(1);
     });
+  });
+
+  it('removes other selections when COUNT() is selected', async () => {
+    fields.selectedFields = ['foo', 'bar'];
+    document.body.appendChild(fields);
+
+    const removeHandler = jest.fn();
+    fields.addEventListener('fields__removed', removeHandler);
+    const selectHandler = jest.fn();
+    fields.addEventListener('fields__selected', selectHandler);
+
+    const customSelect = fields.shadowRoot.querySelector(
+      'querybuilder-custom-select'
+    );
+    customSelect.dispatchEvent(
+      new CustomEvent('option__selection', { detail: { value: 'COUNT()' } })
+    );
+
+    expect(removeHandler).toHaveBeenCalledTimes(2);
+    expect(selectHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes COUNT() when something else is selected', async () => {
+    fields.selectedFields = ['COUNT()'];
+    document.body.appendChild(fields);
+
+    const removeHandler = jest.fn();
+    fields.addEventListener('fields__removed', removeHandler);
+    const selectHandler = jest.fn();
+    fields.addEventListener('fields__selected', selectHandler);
+
+    const customSelect = fields.shadowRoot.querySelector(
+      'querybuilder-custom-select'
+    );
+    customSelect.dispatchEvent(
+      new CustomEvent('option__selection', { detail: { value: 'foo' } })
+    );
+
+    expect(removeHandler).toHaveBeenCalledTimes(1);
+    expect(selectHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.test.ts
@@ -47,7 +47,7 @@ describe('Fields', () => {
     document.body.appendChild(fields);
 
     const handler = jest.fn();
-    fields.addEventListener('fields__removed', handler);
+    fields.addEventListener('fields__selected', handler);
 
     const selectedFieldCloseEl = fields.shadowRoot.querySelector(
       "[data-field='foo']"
@@ -91,9 +91,11 @@ describe('Fields', () => {
     fields.selectedFields = ['foo', 'bar'];
     document.body.appendChild(fields);
 
-    const removeHandler = jest.fn();
-    fields.addEventListener('fields__removed', removeHandler);
-    const selectHandler = jest.fn();
+
+    let selectionFromEvent;
+    const selectHandler = jest.fn().mockImplementation(e => {
+      selectionFromEvent = e.detail.fields;
+    });
     fields.addEventListener('fields__selected', selectHandler);
 
     const customSelect = fields.shadowRoot.querySelector(
@@ -103,17 +105,18 @@ describe('Fields', () => {
       new CustomEvent('option__selection', { detail: { value: 'COUNT()' } })
     );
 
-    expect(removeHandler).toHaveBeenCalledTimes(2);
     expect(selectHandler).toHaveBeenCalledTimes(1);
+    expect(selectionFromEvent).toEqual(['COUNT()']);
   });
 
   it('removes COUNT() when something else is selected', async () => {
     fields.selectedFields = ['COUNT()'];
     document.body.appendChild(fields);
 
-    const removeHandler = jest.fn();
-    fields.addEventListener('fields__removed', removeHandler);
-    const selectHandler = jest.fn();
+    let selectionFromEvent;
+    const selectHandler = jest.fn().mockImplementation(e => {
+      selectionFromEvent = e.detail.fields;
+    });
     fields.addEventListener('fields__selected', selectHandler);
 
     const customSelect = fields.shadowRoot.querySelector(
@@ -123,7 +126,7 @@ describe('Fields', () => {
       new CustomEvent('option__selection', { detail: { value: 'foo' } })
     );
 
-    expect(removeHandler).toHaveBeenCalledTimes(1);
     expect(selectHandler).toHaveBeenCalledTimes(1);
+    expect(selectionFromEvent).toEqual(['foo']);
   });
 });

--- a/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.test.ts
@@ -8,6 +8,7 @@
 
 import { createElement } from 'lwc';
 import Fields from 'querybuilder/fields';
+import { SELECT_COUNT } from '../services/model';
 
 describe('Fields', () => {
   const fields = createElement('querybuilder-fields', {
@@ -101,15 +102,15 @@ describe('Fields', () => {
       'querybuilder-custom-select'
     );
     customSelect.dispatchEvent(
-      new CustomEvent('option__selection', { detail: { value: 'COUNT()' } })
+      new CustomEvent('option__selection', { detail: { value: SELECT_COUNT } })
     );
 
     expect(selectHandler).toHaveBeenCalledTimes(1);
-    expect(selectionFromEvent).toEqual(['COUNT()']);
+    expect(selectionFromEvent).toEqual([SELECT_COUNT]);
   });
 
   it('removes COUNT() when something else is selected', async () => {
-    fields.selectedFields = ['COUNT()'];
+    fields.selectedFields = [SELECT_COUNT];
     document.body.appendChild(fields);
 
     let selectionFromEvent;

--- a/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.ts
@@ -26,14 +26,16 @@ export default class Fields extends LightningElement {
   handleFieldSelection(e) {
     e.preventDefault();
     if (e.detail && e.detail.value) {
+      let selection = [];
       // COUNT() and other fields are mutually exclusive
       if (e.detail.value.toLowerCase() === 'count()') {
-        this.removeNonCountSelections();
+        selection.push('COUNT()');
       } else {
-        this.removeCountSelection();
+        selection = this.selectedFields.filter(value => value.toLowerCase() !== 'count()');
+        selection.push(e.detail.value);
       }
       const fieldSelectedEvent = new CustomEvent('fields__selected', {
-        detail: { field: e.detail.value }
+        detail: { fields: selection }
       });
       this.dispatchEvent(fieldSelectedEvent);
     }
@@ -41,31 +43,11 @@ export default class Fields extends LightningElement {
 
   handleFieldRemoved(e) {
     e.preventDefault();
-    const fieldRemovedEvent = new CustomEvent('fields__removed', {
-      detail: { field: e.target.dataset.field }
+    const fieldRemovedEvent = new CustomEvent('fields__selected', {
+      detail: { fields: this.selectedFields.filter(value => value !== e.target.dataset.field) }
     });
     this.dispatchEvent(fieldRemovedEvent);
   }
 
-  removeNonCountSelections() {
-    this.selectedFields.forEach(field => {
-      if (field.toLowerCase() !== 'count()') {
-        const fieldRemovedEvent = new CustomEvent('fields__removed', {
-          detail: { field }
-        });
-        this.dispatchEvent(fieldRemovedEvent);
-      }
-    });
-  }
 
-  removeCountSelection() {
-    this.selectedFields.forEach(field => {
-      if (field.toLowerCase() === 'count()') {
-        const fieldRemovedEvent = new CustomEvent('fields__removed', {
-          detail: { field }
-        });
-        this.dispatchEvent(fieldRemovedEvent);
-      }
-    });
-  }
 }

--- a/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.ts
@@ -7,10 +7,11 @@
  */
 
 import { LightningElement, api } from 'lwc';
+import { SELECT_COUNT } from '../services/model';
 export default class Fields extends LightningElement {
   @api set fields(fields: string[]) {
     this._displayFields = [
-      'COUNT()',
+      SELECT_COUNT,
       ...fields
     ];
   }
@@ -28,10 +29,10 @@ export default class Fields extends LightningElement {
     if (e.detail && e.detail.value) {
       let selection = [];
       // COUNT() and other fields are mutually exclusive
-      if (e.detail.value.toLowerCase() === 'count()') {
-        selection.push('COUNT()');
+      if (e.detail.value.toLowerCase() === SELECT_COUNT.toLowerCase()) {
+        selection.push(SELECT_COUNT);
       } else {
-        selection = this.selectedFields.filter(value => value.toLowerCase() !== 'count()');
+        selection = this.selectedFields.filter(value => value.toLowerCase() !== SELECT_COUNT.toLowerCase());
         selection.push(e.detail.value);
       }
       const fieldSelectedEvent = new CustomEvent('fields__selected', {

--- a/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.ts
@@ -8,15 +8,30 @@
 
 import { LightningElement, api } from 'lwc';
 export default class Fields extends LightningElement {
-  @api fields: string[];
+  @api set fields(fields: string[]) {
+    this._displayFields = [
+      'COUNT()',
+      ...fields
+    ];
+  }
+  get fields() {
+    return this._displayFields;
+  }
   @api selectedFields: string[] = [];
   @api hasError = false;
   @api isLoading = false;
   selectPlaceHolderText = 'Search fields...'; // TODO: i18n
+  _displayFields: string[];
 
   handleFieldSelection(e) {
     e.preventDefault();
     if (e.detail && e.detail.value) {
+      // COUNT() and other fields are mutually exclusive
+      if (e.detail.value.toLowerCase() === 'count()') {
+        this.removeNonCountSelections();
+      } else {
+        this.removeCountSelection();
+      }
       const fieldSelectedEvent = new CustomEvent('fields__selected', {
         detail: { field: e.detail.value }
       });
@@ -30,5 +45,27 @@ export default class Fields extends LightningElement {
       detail: { field: e.target.dataset.field }
     });
     this.dispatchEvent(fieldRemovedEvent);
+  }
+
+  removeNonCountSelections() {
+    this.selectedFields.forEach(field => {
+      if (field.toLowerCase() !== 'count()') {
+        const fieldRemovedEvent = new CustomEvent('fields__removed', {
+          detail: { field }
+        });
+        this.dispatchEvent(fieldRemovedEvent);
+      }
+    });
+  }
+
+  removeCountSelection() {
+    this.selectedFields.forEach(field => {
+      if (field.toLowerCase() === 'count()') {
+        const fieldRemovedEvent = new CustomEvent('fields__removed', {
+          detail: { field }
+        });
+        this.dispatchEvent(fieldRemovedEvent);
+      }
+    });
   }
 }

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/model.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/model.ts
@@ -27,6 +27,8 @@ export enum AndOr {
   OR = 'OR'
 }
 
+export const SELECT_COUNT = 'COUNT()';
+
 // This is to satisfy TS and stay dry
 export type IMap = Map<string, string | List<string>>;
 // Private immutable interface

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.test.ts
@@ -11,7 +11,7 @@ import {
   soqlStringLiteralToDisplayValue,
   displayValueToSoqlStringLiteral
 } from './soqlUtils';
-import { ToolingModelJson } from './model';
+import { SELECT_COUNT, ToolingModelJson } from './model';
 
 describe('SoqlUtils', () => {
   const uiModelOne: ToolingModelJson = {
@@ -52,7 +52,7 @@ describe('SoqlUtils', () => {
   };
   const uiModelCount: ToolingModelJson = {
     sObject: 'Account',
-    fields: ['COUNT()'],
+    fields: [SELECT_COUNT],
     where: {
       conditions: [],
       andOr: undefined

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.test.ts
@@ -49,6 +49,19 @@ describe('SoqlUtils', () => {
     unsupported: [],
     originalSoqlStatement: ''
   };
+  const uiModelCount: ToolingModelJson = {
+    sObject: 'Account',
+    fields: ['COUNT()'],
+    where: {
+      conditions: [],
+      andOr: undefined
+    },
+    orderBy: [],
+    limit: '',
+    errors: [],
+    unsupported: [],
+    originalSoqlStatement: ''
+  };
   const uiModelErrors: ToolingModelJson = {
     sObject: 'Account',
     fields: ['Name'],
@@ -70,6 +83,8 @@ describe('SoqlUtils', () => {
   };
   const soqlOne =
     "Select Name, Id from Account WHERE Name = 'pwt' AND Id = 123456 ORDER BY Name ASC NULLS FIRST LIMIT 11";
+  const soqlCount =
+    "SELECT COUNT() FROM Account";
   const unsupportedWhereExpr =
     "Select Name, Id from Account WHERE (Name = 'pwt' AND Id = 123456) OR Id = 654321 ORDER BY Name ASC NULLS FIRST LIMIT 11";
   const soqlError = 'Select Name from Account GROUP BY';
@@ -91,6 +106,11 @@ describe('SoqlUtils', () => {
     expect(transformedSoql).toContain(uiModelOne.orderBy[0].order);
     expect(transformedSoql).toContain(uiModelOne.orderBy[0].nulls);
     expect(transformedSoql).toContain('11');
+  });
+
+  it('transform UI Model to SOQL with SELECT COUNT() clause', () => {
+    const transformedSoql = convertUiModelToSoql(uiModelCount);
+    expect(transformedSoql).toContain('SELECT COUNT()');
   });
 
   it('transform UI Model to Soql but leaves out errors/unsupported', () => {
@@ -126,6 +146,15 @@ describe('SoqlUtils', () => {
     delete expectedUiModel.originalSoqlStatement;
     expect(JSON.stringify(transformedUiModel)).toEqual(
       JSON.stringify(expectedUiModel)
+    );
+  });
+
+  it('transforms SOQL to UI Model with SELECT COUNT() clause', () => {
+    const transformedUiModel = convertSoqlToUiModel(soqlCount);
+    let expected = { ...uiModelCount } as any;
+    delete expected.originalSoqlStatement;
+    expect(JSON.stringify(transformedUiModel)).toEqual(
+      JSON.stringify(expected)
     );
   });
 

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/soqlUtils.ts
@@ -13,7 +13,7 @@ import {
   ModelDeserializer
 } from '@salesforce/soql-model';
 import { SoqlEditorEvent } from './message/soqlEditorEvent';
-import { ToolingModelJson } from './model';
+import { SELECT_COUNT, ToolingModelJson } from './model';
 
 export function convertSoqlToUiModel(soql: string): ToolingModelJson {
   const queryModel = new ModelDeserializer(soql).deserialize();
@@ -40,7 +40,7 @@ export function convertSoqlModelToUiModel(
           }
           return undefined;
         })
-      : ['COUNT()'];
+      : [SELECT_COUNT];
 
   const sObject = queryModel.from && queryModel.from.sobjectName;
 
@@ -117,7 +117,7 @@ export function convertUiModelToSoql(uiModel: ToolingModelJson): string {
 
 function convertUiModelToSoqlModel(uiModel: ToolingModelJson): Soql.Query {
   let select: Soql.Select;
-  const isSelectCount = uiModel.fields.length === 1 && uiModel.fields[0].toLowerCase() === 'count()';
+  const isSelectCount = uiModel.fields.length === 1 && uiModel.fields[0].toLowerCase() === SELECT_COUNT.toLowerCase();
   if (isSelectCount) {
     select = new Impl.SelectCountImpl();
   } else {

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.test.ts
@@ -80,7 +80,7 @@ describe('Tooling Model Service', () => {
     it('should include originalSoqlStatement property in model', () => {
       expect(query.originalSoqlStatement).toBe('');
       modelService.setSObject('Account');
-      modelService.addField('Id');
+      modelService.setFields(['Id']);
 
       // The formatting of the soql statement is hard to match exactly
       // because the formatter inserts returns and spaces.
@@ -90,25 +90,24 @@ describe('Tooling Model Service', () => {
   });
 
   describe('FIELDS', () => {
-    it('can Add, Delete Fields and saves changes', () => {
+    it('can set fields and changes are reflected', () => {
       (messageService.setState as jest.Mock).mockClear();
       expect(messageService.setState).toHaveBeenCalledTimes(0);
       query = ToolingModelService.toolingModelTemplate;
 
       expect(query!.fields.length).toEqual(0);
 
-      // Add
-      modelService.addField(mockField1);
-      modelService.addField(mockField2);
+      // set
+      modelService.setFields([mockField1, mockField2]);
       expect(query!.fields.length).toBe(2);
       expect(query!.fields).toContain(mockField1);
       expect(query!.fields).toContain(mockField2);
-      // Delete
-      modelService.removeField(mockField1);
+      // modify
+      modelService.setFields([mockField2]);
       expect(query!.fields.length).toBe(1);
       expect(query!.fields).toContain(mockField2);
       // verify saves
-      expect(messageService.setState).toHaveBeenCalledTimes(3);
+      expect(messageService.setState).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -145,7 +144,7 @@ describe('Tooling Model Service', () => {
     it('should send message when ui changes the query', () => {
       expect(messageService.sendMessage).not.toHaveBeenCalled();
       // Add
-      modelService.addField(mockField1);
+      modelService.setFields([mockField1]);
       expect(messageService.sendMessage).toHaveBeenCalled();
     });
 
@@ -355,7 +354,7 @@ describe('Tooling Model Service', () => {
 
     // Now modify the query. The resulting text must retain the comments
     modelService.setSObject('Bar');
-    modelService.addField('Name');
+    modelService.setFields(['Name']);
 
     expect(query.sObject).toEqual('Bar');
     expect(query.fields[0]).toEqual('Name');

--- a/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/services/toolingModelService.ts
@@ -79,26 +79,13 @@ export class ToolingModelService {
     return this.getModel().get(ModelProps.FIELDS) as List<string>;
   }
 
-  public addField(field: string) {
+  public setFields(fields: string[]) {
     const currentModel = this.getModel();
-    const newModelWithAddedField = currentModel.set(
+    const newModel = currentModel.set(
       ModelProps.FIELDS,
-      this.getFields().toSet().add(field).toList()
-    ) as ToolingModel;
-
-    this.changeModel(newModelWithAddedField);
-  }
-
-  public removeField(field: string) {
-    const currentModel = this.getModel();
-    const newModelWithFieldRemoved = currentModel.set(
-      ModelProps.FIELDS,
-      this.getFields().filter((item) => {
-        return item !== field;
-      }) as List<string>
-    ) as ToolingModel;
-
-    this.changeModel(newModelWithFieldRemoved);
+      fields
+    );
+    this.changeModel(newModel);
   }
 
   /* ---- ORDER BY ---- */

--- a/packages/soql-model/src/model/impl/index.ts
+++ b/packages/soql-model/src/model/impl/index.ts
@@ -16,6 +16,7 @@ import { SelectExprsImpl } from './selectExprsImpl';
 import { WhereImpl } from './whereImpl';
 import { UnmodeledSyntaxImpl } from './unmodeledSyntaxImpl';
 import { HeaderCommentsImpl } from './headerCommentsImpl';
+import { SelectCountImpl } from './selectCountImpl';
 
 export {
   AndOrConditionImpl,
@@ -36,4 +37,5 @@ export {
   WhereImpl,
   UnmodeledSyntaxImpl,
   HeaderCommentsImpl,
+  SelectCountImpl
 };

--- a/packages/soql-model/src/model/impl/selectCountImpl.test.ts
+++ b/packages/soql-model/src/model/impl/selectCountImpl.test.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Impl from '.';
+
+describe('SelectCountImpl should', () => {
+  it('return "SELECT COUNT()" for toSoqlSyntax()', () => {
+    const expected = 'SELECT COUNT()';
+    const actual = new Impl.SelectCountImpl().toSoqlSyntax();
+    expect(actual).toEqual(expected);
+  });
+});

--- a/packages/soql-model/src/model/impl/selectCountImpl.ts
+++ b/packages/soql-model/src/model/impl/selectCountImpl.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Soql from '../model';
+import { SoqlModelObjectImpl } from './soqlModelObjectImpl';
+
+export class SelectCountImpl extends SoqlModelObjectImpl
+  implements Soql.SelectCount {
+  public constructor() {
+    super();
+  }
+  public toSoqlSyntax(options?: Soql.SyntaxOptions): string {
+    return 'SELECT COUNT()';
+  }
+}

--- a/packages/soql-model/src/model/model.ts
+++ b/packages/soql-model/src/model/model.ts
@@ -95,8 +95,11 @@ export interface From extends SoqlModelObject {
 }
 
 export interface Select extends SoqlModelObject {
-  // SELECT COUNT() => UnmodeledSyntax
+  // SELECT COUNT() => SelectCount
   // SELECT [field] [subquery] [typeof] [distance] => SelectExprs
+}
+
+export interface SelectCount extends Select {
 }
 
 export interface SelectExprs extends Select {
@@ -246,7 +249,7 @@ export interface RecordTrackingType extends SoqlModelObject { }
 export interface Update extends SoqlModelObject { }
 
 export interface UnmodeledSyntax
-  extends Select,
+  extends
   SelectExpression,
   Field,
   Condition,

--- a/packages/soql-model/src/serialization/deserializer.test.ts
+++ b/packages/soql-model/src/serialization/deserializer.test.ts
@@ -74,10 +74,7 @@ const fromWithUnmodeledSyntax = {
   },
 };
 
-const selectCountUnmdeledSyntax = {
-  unmodeledSyntax: 'SELECT COUNT()',
-  reason: 'unmodeled:count',
-};
+const selectCount = {};
 
 const limitZero = { limit: 0 };
 
@@ -183,9 +180,9 @@ describe('ModelDeserializer should', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('model COUNT() in SELECT clause as unmodeled syntax', () => {
+  it('identify SELECT COUNT() clause', () => {
     const expected = {
-      select: selectCountUnmdeledSyntax,
+      select: selectCount,
       from: testQueryModel.from,
       errors: testQueryModel.errors,
     };
@@ -199,7 +196,7 @@ describe('ModelDeserializer should', () => {
     const expected = testQueryModel;
     const actual = new ModelDeserializer(
       'SELECT field1, field2, field3 alias3, COUNT(fieldZ), (SELECT fieldA FROM objectA), TYPEOF obj WHEN typeX THEN fieldX ELSE fieldY END FROM object1 ' +
-        'WHERE field1 = 5 WITH DATA CATEGORY cat__c AT val__c GROUP BY field1 ORDER BY field2 DESC NULLS LAST, field1 LIMIT 20 OFFSET 2 BIND field1 = 5 FOR VIEW UPDATE TRACKING'
+      'WHERE field1 = 5 WITH DATA CATEGORY cat__c AT val__c GROUP BY field1 ORDER BY field2 DESC NULLS LAST, field1 LIMIT 20 OFFSET 2 BIND field1 = 5 FOR VIEW UPDATE TRACKING'
     ).deserialize();
     expect(actual).toEqual(expected);
   });

--- a/packages/soql-model/src/serialization/deserializer.ts
+++ b/packages/soql-model/src/serialization/deserializer.ts
@@ -509,7 +509,7 @@ class QueryListener implements SoqlParserListener {
         this.select = new Impl.SelectExprsImpl(this.selectExpressions);
       } else if (selectCtx instanceof Parser.SoqlSelectCountClauseContext) {
         // not a modeled case
-        this.select = this.toUnmodeledSyntax(selectCtx.start, selectCtx.stop as Token, 'unmodeled:count');
+        this.select = new Impl.SelectCountImpl();
       } else {
         // no selections
         this.select = new Impl.SelectExprsImpl([]);


### PR DESCRIPTION
### What does this PR do?
This PR adds COUNT() to the SOQL model and the SOQL builder fields selector. COUNT() and other fields are mutually exclusive, so when COUNT() is selected, all other selections are cleared. When some other field is selected, COUNT() is removed.


https://user-images.githubusercontent.com/55159130/107048442-f2ba8f00-6796-11eb-87cf-61c9dc7e3a63.mov


### What issues does this PR fix or reference?
@W-8786165@