### PR TITLE
build: upon release, create version bump commit only if necessary

### DIFF
--- a/.github/workflows/release-soql-model.yml
+++ b/.github/workflows/release-soql-model.yml
@@ -32,11 +32,12 @@ jobs:
         run: |
          SOQL_MODEL_VERSION=${{ steps.release.outputs.major}}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch}}
          sed -i.back -E 's/"@salesforce\/soql-model": +"[^"]+"/"@salesforce\/soql-model": "'$SOQL_MODEL_VERSION'"/g' packages/*/package.json
-         git diff
-         git config --local user.email "$(git log --format='%ae' HEAD^!)"
-         git config --local user.name "$(git log --format='%an' HEAD^!)"
-         git commit -a -m "chore: bump soql-model version on soql-builder-ui to $SOQL_MODEL_VERSION"
-         git push
+         if ! git diff --exit-code; then
+           git config --local user.email "$(git log --format='%ae' HEAD^!)"
+           git config --local user.name "$(git log --format='%an' HEAD^!)"
+           git commit -a -m "chore: bump soql-model version on soql-builder-ui to $SOQL_MODEL_VERSION"
+           git push
+         fi
         if: ${{ steps.release.outputs.release_created }}
       - name: build-and-publish
         run: |


### PR DESCRIPTION
### What does this PR do?
Improve release action script: don't bump soql-model deps versions if it was already done on the release PR branch

### What issues does this PR fix or reference?
N/A