### PR TITLE
build: update internal dependency versions on release PRs

### DIFF
--- a/.github/workflows/release-soql-builder-ui.yml
+++ b/.github/workflows/release-soql-builder-ui.yml
@@ -20,21 +20,38 @@ jobs:
           path: packages/soql-builder-ui
           monorepo-tags: true
           default-branch: main
+      - run: |
+          echo 'Release outputs:${{ toJSON(steps.release.outputs) }}'
+        # Case 1:
+        # If this is not the result of a Release PR merge, then update version
+        # of internal dependencies on the release branch
       - uses: actions/checkout@v2
-        # these if statements ensure that a publication only occurs when
-        # a new release is created (when merging a release PR to main):
+        if: ${{ ! steps.release.outputs.release_created }}
+      - name: bump-inter-dependencies-on-release-branch
+        if: ${{ ! steps.release.outputs.release_created }}
+        run: ./scripts/gh-action-bump-interdeps-versions-on-release-branch.sh soql-builder-ui
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Case 2:
+        # If this IS the result of a Release PR merge into main, then proceed to publish
+        # the npm package
+      - uses: actions/checkout@v2
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
+        if: ${{ steps.release.outputs.release_created }}
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
           scope: '@salesforce'
+      - name: build
         if: ${{ steps.release.outputs.release_created }}
-      - run: |
+        run: |
          yarn
          yarn build
-         cd packages/soql-builder-ui
-         npm publish
+      - name: publish
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          cd packages/soql-builder-ui
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-soql-common.yml
+++ b/.github/workflows/release-soql-common.yml
@@ -20,33 +20,38 @@ jobs:
           path: packages/soql-common
           monorepo-tags: true
           default-branch: main
+      - run: |
+          echo 'Release outputs:${{ toJSON(steps.release.outputs) }}'
+        # Case 1:
+        # If this is not the result of a Release PR merge, then update version
+        # of internal dependencies on the release branch
       - uses: actions/checkout@v2
-        # these if statements ensure that a publication only occurs when
-        # a new release is created (when merging a release PR to main):
+        if: ${{ ! steps.release.outputs.release_created }}
+      - name: bump-inter-dependencies-on-release-branch
+        if: ${{ ! steps.release.outputs.release_created }}
+        run: ./scripts/gh-action-bump-interdeps-versions-on-release-branch.sh soql-common
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Case 2:
+        # If this IS the result of a Release PR merge into main, then proceed to publish
+        # the npm package
+      - uses: actions/checkout@v2
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
+        if: ${{ steps.release.outputs.release_created }}
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
           scope: '@salesforce'
+      - name: build
         if: ${{ steps.release.outputs.release_created }}
-      - name: bump-dependencies-to-soql-common
-        run: |
-         SOQL_MODEL_VERSION=${{ steps.release.outputs.major}}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch}}
-         sed -i.back -E 's/"@salesforce\/soql-common": +"[^"]+"/"@salesforce\/soql-common": "'$SOQL_MODEL_VERSION'"/g' packages/*/package.json
-         if ! git diff --exit-code; then
-           git config --local user.email "$(git log --format='%ae' HEAD^!)"
-           git config --local user.name "$(git log --format='%an' HEAD^!)"
-           git commit -a -m "chore: bump soql-common version on soql-builder-ui to $SOQL_MODEL_VERSION"
-           git push
-         fi
-        if: ${{ steps.release.outputs.release_created }}
-      - name: build-and-publish
         run: |
          yarn
          yarn build
-         cd packages/soql-common
-         npm publish
+      - name: publish
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          cd packages/soql-common
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-soql-data-view.yml
+++ b/.github/workflows/release-soql-data-view.yml
@@ -20,21 +20,38 @@ jobs:
           path: packages/soql-data-view
           monorepo-tags: true
           default-branch: main
+      - run: |
+          echo 'Release outputs:${{ toJSON(steps.release.outputs) }}'
+        # Case 1:
+        # If this is not the result of a Release PR merge, then update version
+        # of internal dependencies on the release branch
       - uses: actions/checkout@v2
-        # these if statements ensure that a publication only occurs when
-        # a new release is created (when merging a release PR to main):
+        if: ${{ ! steps.release.outputs.release_created }}
+      - name: bump-inter-dependencies-on-release-branch
+        if: ${{ ! steps.release.outputs.release_created }}
+        run: ./scripts/gh-action-bump-interdeps-versions-on-release-branch.sh soql-data-view
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Case 2:
+        # If this IS the result of a Release PR merge into main, then proceed to publish
+        # the npm package
+      - uses: actions/checkout@v2
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
+        if: ${{ steps.release.outputs.release_created }}
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
           scope: '@salesforce'
+      - name: build
         if: ${{ steps.release.outputs.release_created }}
-      - run: |
+        run: |
          yarn
          yarn build
-         cd packages/soql-data-view
-         npm publish
+      - name: publish
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          cd packages/soql-data-view
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-soql-model.yml
+++ b/.github/workflows/release-soql-model.yml
@@ -20,33 +20,38 @@ jobs:
           path: packages/soql-model
           monorepo-tags: true
           default-branch: main
+      - run: |
+          echo 'Release outputs:${{ toJSON(steps.release.outputs) }}'
+        # Case 1:
+        # If this is not the result of a Release PR merge, then update version
+        # of internal dependencies on the release branch
       - uses: actions/checkout@v2
-        # these if statements ensure that a publication only occurs when
-        # a new release is created (when merging a release PR to main):
+        if: ${{ ! steps.release.outputs.release_created }}
+      - name: bump-inter-dependencies-on-release-branch
+        if: ${{ ! steps.release.outputs.release_created }}
+        run: ./scripts/gh-action-bump-interdeps-versions-on-release-branch.sh soql-model
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Case 2:
+        # If this IS the result of a Release PR merge into main, then proceed to publish
+        # the npm package
+      - uses: actions/checkout@v2
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
+        if: ${{ steps.release.outputs.release_created }}
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
           scope: '@salesforce'
+      - name: build
         if: ${{ steps.release.outputs.release_created }}
-      - name: bump-dependencies-to-soql-model
-        run: |
-         SOQL_MODEL_VERSION=${{ steps.release.outputs.major}}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch}}
-         sed -i.back -E 's/"@salesforce\/soql-model": +"[^"]+"/"@salesforce\/soql-model": "'$SOQL_MODEL_VERSION'"/g' packages/*/package.json
-         if ! git diff --exit-code; then
-           git config --local user.email "$(git log --format='%ae' HEAD^!)"
-           git config --local user.name "$(git log --format='%an' HEAD^!)"
-           git commit -a -m "chore: bump soql-model version on soql-builder-ui to $SOQL_MODEL_VERSION"
-           git push
-         fi
-        if: ${{ steps.release.outputs.release_created }}
-      - name: build-and-publish
         run: |
          yarn
          yarn build
-         cd packages/soql-model
-         npm publish
+      - name: publish
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          cd packages/soql-model
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}

--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
   "workspaces": {
     "packages": [
       "packages/*"
-    ],
-    "nohoist": [
-      "**/@salesforce/soql-parser",
-      "**/@salesforce/soql-parser/**"
     ]
   },
   "dependencies": {},

--- a/scripts/gh-action-bump-interdeps-versions-on-release-branch.sh
+++ b/scripts/gh-action-bump-interdeps-versions-on-release-branch.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+
+RELEASE_BRANCH_PREFIX=$1
+if [ -z "$RELEASE_BRANCH_PREFIX" ]; then
+  echo "Must release branch prefix to filter out the PRs"
+  exit 1
+fi
+echo RELEASE_BRANCH_PREFIX=$RELEASE_BRANCH_PREFIX
+
+gh --version
+PR_LIST_FILE=$(mktemp)
+gh pr list --label "autorelease: pending" |grep ${RELEASE_BRANCH_PREFIX} >> $PR_LIST_FILE
+PR_COUNT=$(cat $PR_LIST_FILE | wc -l)
+
+echo PR_COUNT:$PR_COUNT
+if [ $PR_COUNT -ne 1 ]; then
+  echo "Error: the given pattern must match one and only one PR"
+  exit 2
+fi
+
+PR=$(cat $PR_LIST_FILE | cut -f 1)
+rm $PR_LIST_FILE
+echo "PR is ${PR}"
+
+gh pr checkout $PR
+echo "Updating internal dependencies..."
+./scripts/update-interdependency-versions.js packages/*/package*.json
+if ! git diff --ignore-all-space --exit-code; then
+  git config --local user.email "$(git log --format='%ae' HEAD^!)"
+  git config --local user.name "$(git log --format='%an' HEAD^!)"
+  git commit -a -m "chore: bump version of internal dependencies"
+  git push
+else
+  echo "No version changes"
+fi

--- a/scripts/update-interdependency-versions.js
+++ b/scripts/update-interdependency-versions.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var path = require('path');
+
+let packageFiles = process.argv.slice(2);
+if(packageFiles.length <= 0) {
+  console.log('Usage:\n ./scripts/'+ path.basename(__filename)+' <package.json files>');
+  console.log('Example:\n ./scripts/'+path.basename(__filename)+' packages/*/package.json');
+  process.exit(1);
+}
+
+let package2version = packageFiles.reduce((packagesMap, packageFile) => {
+  let package = require('../' + packageFile);
+  packagesMap[package.name] = package.version;
+  return packagesMap;
+}, {});
+
+console.log(package2version);
+
+for (p in packageFiles) {
+  let packageFile = packageFiles[p];
+  let package = require('../' + packageFile);
+  let changed = false;
+  for (packageName in package2version) {
+    if (
+      package.dependencies &&
+      package.dependencies[packageName] &&
+      package.dependencies[packageName] !== package2version[packageName]
+    ) {
+      package.dependencies[packageName] = package2version[packageName];
+      changed = true;
+    }
+    if (
+      package.devDependencies &&
+      package.devDependencies[packageName] &&
+      package.devDependencies[packageName] !== package2version[packageName]
+    ) {
+      package.devDependencies[packageName] = package2version[packageName];
+      changed = true;
+    }
+  }
+  if (changed) {
+    fs.writeFile(
+      packageFile,
+      JSON.stringify(package, null, 2),
+      'utf8',
+      (err) => {
+        if (err) throw err;
+        console.log(
+          `Updated ${packageName} dependency version on ${packageFile}`
+        );
+      }
+    );
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Improve release scripts to automatically keep the version inter-dependencies updated on the release PRs.

Example: On the release PR for soql-model,  the script now updates soql-builder-ui's package.json to depend on the new version.

### What issues does this PR fix or reference?
W-8700164