### PR TITLE
chore: override soql-common release version

### DIFF
--- a/packages/soql-common/package.json
+++ b/packages/soql-common/package.json
@@ -34,3 +34,4 @@
   },
   "license": "BSD-3-Clause"
 }
+


### PR DESCRIPTION
Release-As: 0.2.0

### What does this PR do?
Override the version number inferred by "release-please" script

