### PR TITLE
fix: super simple basic input maxlength controls

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.html
@@ -11,7 +11,7 @@
         onkeydown={handleKeyDown}
         onfocus={handleInputFocus}
         onblur={handleInputFocus}
-        maxlength="100"
+        maxlength="40"
       />
       <template if:true={hasSearchTerm}>
         <div

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.html
@@ -11,6 +11,7 @@
         onkeydown={handleKeyDown}
         onfocus={handleInputFocus}
         onblur={handleInputFocus}
+        maxlength="100"
       />
       <template if:true={hasSearchTerm}>
         <div
@@ -33,8 +34,20 @@
           data-el-chevron
         >
           <svg height="10" width="12">
-            <line x1="2" y1="2" x2="5.5" y2="5.5" style="stroke-width:1.75;stroke-linecap:square;" />
-            <line x1="5.5" y1="5.5" x2="9" y2="2" style="stroke-width:1.75;stroke-linecap:square;" />
+            <line
+              x1="2"
+              y1="2"
+              x2="5.5"
+              y2="5.5"
+              style="stroke-width: 1.75; stroke-linecap: square"
+            />
+            <line
+              x1="5.5"
+              y1="5.5"
+              x2="9"
+              y2="2"
+              style="stroke-width: 1.75; stroke-linecap: square"
+            />
           </svg>
         </div>
       </template>

--- a/packages/soql-builder-ui/src/modules/querybuilder/limit/limit.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/limit/limit.html
@@ -28,6 +28,7 @@
         data-el-limit
         onchange={handleLimitChange}
         onkeyup={handleLimitChange}
+        max="2000"
       />
     </div>
   </div>

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.html
@@ -43,6 +43,7 @@
         type="text"
         oninput={handleSelectionEvent}
         value={criteriaDisplayValue}
+        maxlength="250"
         data-el-where-criteria-input
       />
     </span>


### PR DESCRIPTION
### What does this PR do?
In honor of today's threat model conference, i implemented the most basic of html form input controls...maxlength.  And these limits i added are just a sanity upper limit, to prevent some kinda of performance degradation with vscode or possible "network congestions / buffer overflow" issue with the api. 

The threat model here is awkward, since pasting like 10,000 characters into the where criteria would likely only cause issues with vscode.  And the salesforce soql api that we query is well protected.  At least this would prevent a HUGE api call with some giant WHERE criteria. 

These controls aren't testable, since we don't actually type into the input elements during the tests, these limits can be broken with javascript.

For the @salesforce/soql-data-view module, the Tabulator library handles field display sanitation already. 

>  "To guard against code injection, any formatters that are meant to display text (plaintext, textarea, money, email, link) have the data sanitized first to escape any potentially harmful HTML or JavaScript from making into the table, this causes any such data to be displayed as its plain text alternative. "

See [Built In Formatters](http://tabulator.info/docs/4.9/format).

### What issues does this PR fix or reference?
