### PR TITLE
build: set npm registry explicitly to fix npm publish auth errors

### DIFF
--- a/.github/workflows/release-soql-builder-ui.yml
+++ b/.github/workflows/release-soql-builder-ui.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@salesforce'
         if: ${{ steps.release.outputs.release_created }}
       - run: |
          yarn

--- a/.github/workflows/release-soql-common.yml
+++ b/.github/workflows/release-soql-common.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@salesforce'
         if: ${{ steps.release.outputs.release_created }}
       - name: bump-dependencies-to-soql-common
         run: |

--- a/.github/workflows/release-soql-data-view.yml
+++ b/.github/workflows/release-soql-data-view.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@salesforce'
         if: ${{ steps.release.outputs.release_created }}
       - run: |
          yarn


### PR DESCRIPTION
### What does this PR do?
Configures Github action "setup-node" with an explicit npm registry url. Otherwise, it seems to not take our NPM_TOKEN.

### What issues does this PR fix or reference?
W-8700164