### PR TITLE
feat: provide accessible labels

### DIFF
--- a/packages/soql-builder-ui/package.json
+++ b/packages/soql-builder-ui/package.json
@@ -9,7 +9,7 @@
   },
   "//dependencies": {
     "comments": "since these are all webpacked, they are moved to devDependencies",
-    "@salesforce/soql-model": "0.1.22",
+    "@salesforce/soql-model": "current version in ../soql-model/package.json",
     "debounce": "^1.2.0",
     "immutable": "3.8.2",
     "rxjs": "^6.6.2"

--- a/packages/soql-builder-ui/src/modules/querybuilder/app/app.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/app/app.html
@@ -17,82 +17,96 @@
     </header>
     <article class="querybuilder-body">
       <section class="querybuilder-form">
-        <template if:false={shouldBlockQueryBuilder}>
-          <querybuilder-from
-            onfrom__object_selected={handleObjectChange}
-            sobjects={sObjects}
-            selected={query.sObject}
-            has-error={hasRecoverableFromError}
-            is-loading={isFromLoading}
-            class={theme}
-          ></querybuilder-from>
-          <querybuilder-fields
-            selected-fields={query.fields}
-            fields={fields}
-            onfields__selected={handleFieldSelected}
-            has-error={hasRecoverableFieldsError}
-            is-loading={isFieldsLoading}
-            class={theme}
-          ></querybuilder-fields>
-          <querybuilder-where
-            where-expr={query.where}
-            where-fields={fields}
-            onwhere__group_selection={handleWhereSelection}
-            onwhere__andor_selection={handleAndOrSelection}
-            onwhere__condition_removed={handleRemoveWhereCondition}
-            is-loading={isFieldsLoading}
-            class={theme}
-            sobject-metadata={sobjectMetadata}
-          ></querybuilder-where>
-          <querybuilder-order-by
-            selected-order-by-fields={query.orderBy}
-            order-by-fields={fields}
-            onorderby__selected={handleOrderBySelected}
-            onorderby__removed={handleOrderByRemoved}
-            has-error={hasRecoverableOrderByError}
-            is-loading={isFieldsLoading}
-            class={theme}
-          ></querybuilder-order-by>
-          <querybuilder-limit
-            limit={query.limit}
-            has-error={hasRecoverableLimitError}
-            onlimit__changed={handleLimitChanged}
-            class={theme}
-          ></querybuilder-limit>
-        </template>
-        <template if:true={shouldBlockQueryBuilder}>
-          <div class="warning-notification">
-            <div class="warning-notification__message">
-              <template if:true={showUnsupportedNotification}>
-                <!-- TODO: i18n -->
-                <strong>Your query contains statements that SOQL Builder doesn't currently
-                support.</strong><p>You can use a a text editor to edit the query. If you
-                click Edit Query Anyway, SOQL Builder removes the unsupported syntax.</p>
-              </template>
-              <template if:true={showSyntaxErrorNotification}>
-                <!-- TODO: i18n -->
-                <strong>Your query contains syntax errors that SOQL Builder can't parse.</strong><p>You can use a
-                a text editor to edit the query. If you click Edit Query Anyway, SOQL
-                Builder will rewrite your query.</p>
-              </template>
-              <ol type="number">
-                <template for:each={notifications} for:item="notification"
-                  ><li key={notification.index}>
-                    {notification.item}
-                  </li></template
+        <form>
+          <template if:false={shouldBlockQueryBuilder}>
+            <querybuilder-from
+              onfrom__object_selected={handleObjectChange}
+              sobjects={sObjects}
+              selected={query.sObject}
+              has-error={hasRecoverableFromError}
+              is-loading={isFromLoading}
+              class={theme}
+            ></querybuilder-from>
+            <querybuilder-fields
+              selected-fields={query.fields}
+              fields={fields}
+              onfields__selected={handleFieldSelected}
+              has-error={hasRecoverableFieldsError}
+              is-loading={isFieldsLoading}
+              class={theme}
+            ></querybuilder-fields>
+            <querybuilder-where
+              where-expr={query.where}
+              where-fields={fields}
+              onwhere__group_selection={handleWhereSelection}
+              onwhere__andor_selection={handleAndOrSelection}
+              onwhere__condition_removed={handleRemoveWhereCondition}
+              is-loading={isFieldsLoading}
+              class={theme}
+              sobject-metadata={sobjectMetadata}
+            ></querybuilder-where>
+            <querybuilder-order-by
+              selected-order-by-fields={query.orderBy}
+              order-by-fields={fields}
+              onorderby__selected={handleOrderBySelected}
+              onorderby__removed={handleOrderByRemoved}
+              has-error={hasRecoverableOrderByError}
+              is-loading={isFieldsLoading}
+              class={theme}
+            ></querybuilder-order-by>
+            <querybuilder-limit
+              limit={query.limit}
+              has-error={hasRecoverableLimitError}
+              onlimit__changed={handleLimitChanged}
+              class={theme}
+            ></querybuilder-limit>
+          </template>
+          <template if:true={shouldBlockQueryBuilder}>
+            <div class="warning-notification">
+              <div class="warning-notification__message">
+                <template if:true={showUnsupportedNotification}>
+                  <!-- TODO: i18n -->
+                  <strong
+                    >Your query contains statements that SOQL Builder doesn't
+                    currently support.</strong
+                  >
+                  <p>
+                    You can use a a text editor to edit the query. If you click
+                    Edit Query Anyway, SOQL Builder removes the unsupported
+                    syntax.
+                  </p>
+                </template>
+                <template if:true={showSyntaxErrorNotification}>
+                  <!-- TODO: i18n -->
+                  <strong
+                    >Your query contains syntax errors that SOQL Builder can't
+                    parse.</strong
+                  >
+                  <p>
+                    You can use a a text editor to edit the query. If you click
+                    Edit Query Anyway, SOQL Builder will rewrite your query.
+                  </p>
+                </template>
+                <ol type="number">
+                  <template for:each={notifications} for:item="notification"
+                    ><li key={notification.index}>
+                      {notification.item}
+                    </li></template
+                  >
+                </ol>
+              </div>
+              <div class="warning-notification__dismiss">
+                <button
+                  class="btn--error text-center"
+                  onclick={handleDismissNotifications}
                 >
-              </ol>
+                  <!-- TODO: i18n -->
+                  Edit Query Anyway
+                </button>
+              </div>
             </div>
-            <div class="warning-notification__dismiss">
-              <button
-                class="btn--error text-center"
-                onclick={handleDismissNotifications}
-              ><!-- TODO: i18n -->
-                Edit Query Anyway
-              </button>
-            </div>
-          </div>
-        </template>
+          </template>
+        </form>
       </section>
       <section class="query-preview">
         <querybuilder-query-preview

--- a/packages/soql-builder-ui/src/modules/querybuilder/cssCommon/cssCommon.css
+++ b/packages/soql-builder-ui/src/modules/querybuilder/cssCommon/cssCommon.css
@@ -226,3 +226,14 @@ button:active {
 .text-right {
   text-align: right;
 }
+
+.aria-label {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.html
@@ -11,6 +11,7 @@
         onkeydown={handleKeyDown}
         onfocus={handleInputFocus}
         onblur={handleInputFocus}
+        aria-label={ariaLabel}
         maxlength="40"
       />
       <template if:true={hasSearchTerm}>

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.html
@@ -1,7 +1,9 @@
 <template>
   <main class="custom-select">
     <div class="select__wrapper">
+      <label for="custom-select-input" hidden>{ariaLabelText}</label>
       <input
+        id="custom-select-input"
         class="select__input"
         name="search-bar"
         placeholder={placeholderText}
@@ -11,7 +13,6 @@
         onkeydown={handleKeyDown}
         onfocus={handleInputFocus}
         onblur={handleInputFocus}
-        aria-label={ariaLabel}
         maxlength="40"
       />
       <template if:true={hasSearchTerm}>

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.html
@@ -1,7 +1,6 @@
 <template>
   <main class="custom-select">
     <div class="select__wrapper">
-      <label for="custom-select-input" hidden>{ariaLabelText}</label>
       <input
         id="custom-select-input"
         class="select__input"
@@ -13,6 +12,7 @@
         onkeydown={handleKeyDown}
         onfocus={handleInputFocus}
         onblur={handleInputFocus}
+        aria-label={ariaLabelText}
         maxlength="40"
       />
       <template if:true={hasSearchTerm}>

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.test.ts
@@ -19,6 +19,7 @@ describe('Custom Select', () => {
   const OPTION_BAZ = 'Baz';
   const PLACEHOLDER = 'placeholder';
   const ARIA_HIDDEN = 'aria-hidden';
+  const ARIA_LABEL = 'Field';
   const DATA_OPTION_VALUE = 'data-option-value';
   const OPTION_HIGHLIGHT = 'option--highlight';
   const EVENT_OPTION_SELECTION = 'option__selection';
@@ -38,8 +39,8 @@ describe('Custom Select', () => {
     return customSelect.shadowRoot.querySelector('.select__clear-search');
   };
   const getDropdownTrigger = () => {
-    return customSelect.shadowRoot.querySelector('[data-el-chevron]')
-  }
+    return customSelect.shadowRoot.querySelector('[data-el-chevron]');
+  };
 
   beforeEach(() => {
     customSelect = createElement('querybuilder-custom-select', {
@@ -48,6 +49,7 @@ describe('Custom Select', () => {
     customSelect.allOptions = [OPTION_FOO, OPTION_BAR, OPTION_BAZ];
     customSelect.selectedOptions = [];
     customSelect.multiple = true;
+    customSelect.ariaLabel = 'Field';
   });
 
   afterEach(() => {
@@ -101,6 +103,13 @@ describe('Custom Select', () => {
         const classList = Array.from(searchBar.classList);
         expect(classList).toContain('select__input-placeholder--fadeout');
       });
+    });
+
+    it('should use a provided aria-label', () => {
+      document.body.appendChild(customSelect);
+      let searchBar = getInputSearchBar();
+      const label = searchBar.getAttribute('aria-label');
+      expect(label).toEqual(ARIA_LABEL);
     });
 
     it('should NOT display the options wrapper by default', () => {
@@ -279,7 +288,6 @@ describe('Custom Select', () => {
           expect(selectSpy).toHaveBeenCalled();
         });
       });
-
     });
     describe('Multiple Selection Mode', () => {
       it('should NOT display the selected options as input value', () => {

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.test.ts
@@ -49,7 +49,7 @@ describe('Custom Select', () => {
     customSelect.allOptions = [OPTION_FOO, OPTION_BAR, OPTION_BAZ];
     customSelect.selectedOptions = [];
     customSelect.multiple = true;
-    customSelect.ariaLabel = 'Field';
+    customSelect.ariaLabel = ARIA_LABEL;
   });
 
   afterEach(() => {

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.test.ts
@@ -49,7 +49,7 @@ describe('Custom Select', () => {
     customSelect.allOptions = [OPTION_FOO, OPTION_BAR, OPTION_BAZ];
     customSelect.selectedOptions = [];
     customSelect.multiple = true;
-    customSelect.ariaLabel = ARIA_LABEL;
+    customSelect.ariaLabelText = ARIA_LABEL;
   });
 
   afterEach(() => {
@@ -105,11 +105,10 @@ describe('Custom Select', () => {
       });
     });
 
-    it('should use a provided aria-label', () => {
+    it('should use a provided hidden label', () => {
       document.body.appendChild(customSelect);
-      let searchBar = getInputSearchBar();
-      const label = searchBar.getAttribute('aria-label');
-      expect(label).toEqual(ARIA_LABEL);
+      const label = customSelect.shadowRoot.querySelector('label');
+      expect(label.innerHTML).toEqual(ARIA_LABEL);
     });
 
     it('should NOT display the options wrapper by default', () => {

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.ts
@@ -24,7 +24,7 @@ export default class CustomSelect extends LightningElement {
   @api multiple = false;
   @api isLoading = false;
   @api allOptions: string[];
-  @api ariaLabel: string;
+  @api ariaLabelText: string;
   @track _renderedOptions: string[] = [];
   availableOptions: string[] = [];
   searchTerm = '';
@@ -108,6 +108,10 @@ export default class CustomSelect extends LightningElement {
 
   get isMultipleSelect() {
     return this.multiple;
+  }
+
+  get ariaLabelId() {
+    return `${this.ariaLabel}-${this.id}`;
   }
 
   /* ======= LIFECYCLE HOOKS ======= */

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.ts
@@ -24,6 +24,7 @@ export default class CustomSelect extends LightningElement {
   @api multiple = false;
   @api isLoading = false;
   @api allOptions: string[];
+  @api ariaLabel: string;
   @track _renderedOptions: string[] = [];
   availableOptions: string[] = [];
   searchTerm = '';

--- a/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/customSelect/customSelect.ts
@@ -110,10 +110,6 @@ export default class CustomSelect extends LightningElement {
     return this.multiple;
   }
 
-  get ariaLabelId() {
-    return `${this.ariaLabel}-${this.id}`;
-  }
-
   /* ======= LIFECYCLE HOOKS ======= */
 
   // close the options menu when user clicks outside component

--- a/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.html
@@ -27,15 +27,14 @@
         onoption__selection={handleFieldSelection}
         placeholder-text={selectPlaceHolderText}
         multiple="true"
-        aria-label="Field"
+        aria-label-text="Select Field"
       ></querybuilder-custom-select>
-      <div class="selected-fields-container" aria-label="Selected Fields">
+      <div class="selected-fields-container">
         <template for:each={selectedFields} for:item="field">
           <div class="selected-field" key={field}>
             {field}
             <span
               role="button"
-              aria-label="Delete"
               class="pointer delete-trigger"
               onclick={handleFieldRemoved}
               data-field={field}

--- a/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.html
@@ -27,13 +27,15 @@
         onoption__selection={handleFieldSelection}
         placeholder-text={selectPlaceHolderText}
         multiple="true"
+        aria-label="Field"
       ></querybuilder-custom-select>
-      <div class="selected-fields-container">
+      <div class="selected-fields-container" aria-label="Selected Fields">
         <template for:each={selectedFields} for:item="field">
           <div class="selected-field" key={field}>
             {field}
             <span
               role="button"
+              aria-label="Delete"
               class="pointer delete-trigger"
               onclick={handleFieldRemoved}
               data-field={field}

--- a/packages/soql-builder-ui/src/modules/querybuilder/from/from.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/from/from.html
@@ -25,6 +25,7 @@
         selected-options={_selectedObject}
         onoption__selection={handleSobjectSelection}
         placeholder-text={selectPlaceHolderText}
+        aria-label="From"
       ></querybuilder-custom-select>
     </div>
   </div>

--- a/packages/soql-builder-ui/src/modules/querybuilder/from/from.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/from/from.html
@@ -25,7 +25,7 @@
         selected-options={_selectedObject}
         onoption__selection={handleSobjectSelection}
         placeholder-text={selectPlaceHolderText}
-        aria-label="From"
+        aria-label-text="From"
       ></querybuilder-custom-select>
     </div>
   </div>

--- a/packages/soql-builder-ui/src/modules/querybuilder/orderBy/orderBy.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/orderBy/orderBy.html
@@ -24,16 +24,12 @@
         is-loading={isLoading}
         all-options={orderByFields}
         placeholder-text={selectPlaceHolderText}
-        aria-label="Field"
+        aria-label-text="Order By Field"
       ></querybuilder-custom-select>
       <div class="group-orderby-modifiers">
         <span class="group-orderby-order">
-          <select
-            id="orderby-order"
-            name="orderby-order"
-            aria-label="Direction"
-            data-el-orderby-order
-          >
+          <label for="orderby-order" hidden>Order By Direction</label>
+          <select id="orderby-order" name="orderby-order" data-el-orderby-order>
             <option value="" class="placeholder" default>Direction...</option>
             <!-- TODO: i18n (maybe) -->
             <option value="ASC">Ascending</option>
@@ -41,12 +37,8 @@
           </select></span
         >
         <span class="group-orderby-nulls">
-          <select
-            id="orderby-nulls"
-            name="orderby-nulls"
-            aria-label="Nulls"
-            data-el-orderby-nulls
-          >
+          <label for="orderby-nulls" hidden>Order By Nulls</label>
+          <select id="orderby-nulls" name="orderby-nulls" data-el-orderby-nulls>
             <option value="" class="placeholder" default>Nulls...</option>
             <!-- TODO: i18n (maybe) -->
             <option value="NULLS FIRST">Nulls First</option>
@@ -56,10 +48,7 @@
         <button onclick={handleOrderBySelected} data-el-add-button>Add</button>
       </div>
 
-      <div
-        class="selected-fields-container"
-        aria-label="Existing Order By Statements"
-      >
+      <div class="selected-fields-container">
         <template for:each={selectedOrderByFields} for:item="field">
           <div class="selected-field" key={field.field}>
             {field.field} {field.order} {field.nulls}

--- a/packages/soql-builder-ui/src/modules/querybuilder/orderBy/orderBy.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/orderBy/orderBy.html
@@ -24,10 +24,16 @@
         is-loading={isLoading}
         all-options={orderByFields}
         placeholder-text={selectPlaceHolderText}
+        aria-label="Field"
       ></querybuilder-custom-select>
       <div class="group-orderby-modifiers">
         <span class="group-orderby-order">
-          <select id="orderby-order" name="orderby-order" data-el-orderby-order>
+          <select
+            id="orderby-order"
+            name="orderby-order"
+            aria-label="Direction"
+            data-el-orderby-order
+          >
             <option value="" class="placeholder" default>Direction...</option>
             <!-- TODO: i18n (maybe) -->
             <option value="ASC">Ascending</option>
@@ -35,7 +41,12 @@
           </select></span
         >
         <span class="group-orderby-nulls">
-          <select id="orderby-nulls" name="orderby-nulls" data-el-orderby-nulls>
+          <select
+            id="orderby-nulls"
+            name="orderby-nulls"
+            aria-label="Nulls"
+            data-el-orderby-nulls
+          >
             <option value="" class="placeholder" default>Nulls...</option>
             <!-- TODO: i18n (maybe) -->
             <option value="NULLS FIRST">Nulls First</option>
@@ -45,7 +56,10 @@
         <button onclick={handleOrderBySelected} data-el-add-button>Add</button>
       </div>
 
-      <div class="selected-fields-container">
+      <div
+        class="selected-fields-container"
+        aria-label="Existing Order By Statements"
+      >
         <template for:each={selectedOrderByFields} for:item="field">
           <div class="selected-field" key={field.field}>
             {field.field} {field.order} {field.nulls}

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.html
@@ -8,6 +8,7 @@
         selected-options={_selectedField}
         placeholder-text={selectPlaceHolderText}
         onoption__selection={handleSelectionEvent}
+        aria-label="Field"
       ></querybuilder-custom-select>
     </div>
     <!-- OPERATORS -->
@@ -19,6 +20,7 @@
         name="operator"
         data-el-where-operator-input
         onchange={handleSelectionEvent}
+        aria-label="Operator"
       >
         <template if:true={hasSelectedOperator}>
           <option value={_selectedOperator.value}>
@@ -44,6 +46,7 @@
         oninput={handleSelectionEvent}
         value={criteriaDisplayValue}
         maxlength="250"
+        aria-label="Value"
         data-el-where-criteria-input
       />
     </span>

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.html
@@ -8,7 +8,7 @@
         selected-options={_selectedField}
         placeholder-text={selectPlaceHolderText}
         onoption__selection={handleSelectionEvent}
-        aria-label="Field"
+        aria-label-text="Where Field"
       ></querybuilder-custom-select>
     </div>
     <!-- OPERATORS -->
@@ -16,11 +16,14 @@
       data-text={operatorErrorMessage}
       class={operatorClasses}
       data-el-where-operator
-      ><select
+    >
+      <label for="operator" hidden>Where Operator</label>
+      <select
+        id="operator"
         name="operator"
         data-el-where-operator-input
         onchange={handleSelectionEvent}
-        aria-label="Operator"
+        aria-label-text="Where Operator"
       >
         <template if:true={hasSelectedOperator}>
           <option value={_selectedOperator.value}>
@@ -40,13 +43,14 @@
       class={criteriaClasses}
       data-el-where-criteria
     >
+      <label for="criteria" hidden>Where Value</label>
       <input
+        id="criteria"
         name="criteria"
         type="text"
         oninput={handleSelectionEvent}
         value={criteriaDisplayValue}
         maxlength="250"
-        aria-label="Value"
         data-el-where-criteria-input
       />
     </span>


### PR DESCRIPTION
### What does this PR do?
This adds labels to some of the more complex soql builder components.  For instance, the triplet WHERE inputs and ORDER BY inputs.  According to the accessibility folks here at salesforce, we need to use hidden labels instead of the aria-label attribute.


### What issues does this PR fix or reference?
@W-8984214@

Interestingly, LWC automatically adds unique id's to elements if you give them an id.  So i don't need to worry about id collision.

<img width="496" alt="Screen Shot 2021-03-11 at 2 31 47 PM" src="https://user-images.githubusercontent.com/599418/110860106-978a2980-8279-11eb-93eb-13188b416962.png">
