### PR TITLE
fix: better align header labels with inputs

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/where/where.css
+++ b/packages/soql-builder-ui/src/modules/querybuilder/where/where.css
@@ -30,18 +30,20 @@ header.header {
   display: flex;
   justify-content: space-around;
   margin-top: 5px;
-  padding-right: 2.5em;
 }
 
 .header__labels p {
-  margin: 0 0.5em 0 0;
+  margin: 0;
 }
 /* better align labels with correct elements below */
 .header__labels p.header__label__field {
-  margin-left: 45px;
+  margin-left: 1rem;
 }
 .header__labels p.header__label__operator {
-  margin-left: 21px;
+  margin-right: 0.5rem;
+}
+.header__labels p.header__label__value {
+  margin-right: 2.75rem;
 }
 
 .header__btn--group {

--- a/packages/soql-builder-ui/src/modules/querybuilder/where/where.html
+++ b/packages/soql-builder-ui/src/modules/querybuilder/where/where.html
@@ -37,7 +37,7 @@
           <!-- i18n -->
           <p class="header__label__field">Field</p>
           <p class="header__label__operator">Operator</p>
-          <p>Value</p>
+          <p class="header__label__value">Value</p>
         </div>
       </header>
       <section class="modifier__group-container">


### PR DESCRIPTION
### What does this PR do?
This PR will fix the misaligned header labels in the where clause.

The CSS will be updated so that the general spacing of each header is controlled with flexbox but the specific alignment is controlled by styles for each header value.
Before: 
![image (2)](https://user-images.githubusercontent.com/25188632/113190488-936a7f80-9219-11eb-84a9-29f94013d45a.png)

After: 
<img width="1191" alt="Screen Shot 2021-03-31 at 12 03 01 PM" src="https://user-images.githubusercontent.com/25188632/113190531-9f564180-9219-11eb-89c6-de84ed1bf35f.png">


