### PR TITLE
feat: update select all label without star

### DIFF
--- a/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { createElement } from 'lwc';
-import Fields from 'querybuilder/fields';
+import Fields, { SELECT_ALL_OPTION, CLEAR_OPTION } from 'querybuilder/fields';
 import { SELECT_COUNT } from '../services/model';
 
 describe('Fields', () => {
@@ -45,9 +45,9 @@ describe('Fields', () => {
         .shadowRoot.querySelectorAll('p[data-option-value]');
 
       expect(dataOptions.length).toEqual(6);
-      expect(dataOptions[0].textContent).toEqual('- Clear Selection -');
-      expect(dataOptions[1].textContent).toEqual('ALL FIELDS');
-      expect(dataOptions[2].textContent).toEqual('COUNT()');
+      expect(dataOptions[0].textContent).toEqual(CLEAR_OPTION);
+      expect(dataOptions[1].textContent).toEqual(SELECT_ALL_OPTION);
+      expect(dataOptions[2].textContent).toEqual(SELECT_COUNT);
       expect(dataOptions[3].textContent).toEqual('foo');
       expect(dataOptions[4].textContent).toEqual('bar');
       expect(dataOptions[5].textContent).toEqual('baz');

--- a/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/fields/fields.ts
@@ -11,8 +11,8 @@
 import { LightningElement, api } from 'lwc';
 import { SELECT_COUNT } from '../services/model';
 
-const SELECT_ALL_OPTION = 'ALL FIELDS';
-const CLEAR_OPTION = '- Clear Selection -';
+export const SELECT_ALL_OPTION = 'ALL FIELDS';
+export const CLEAR_OPTION = '- Clear Selection -';
 
 export default class Fields extends LightningElement {
   @api public set fields(fields: string[]) {


### PR DESCRIPTION
### What does this PR do?

As discussed in https://github.com/forcedotcom/soql-tooling/pull/251#discussion_r629080337, the `*` look like a bullet point in the dropdown. This changes it to `ALL FIELDS` without the `*`.  Not sure if we want to take this direction or not, but offering this PR as a place for discussion. 

![image](https://user-images.githubusercontent.com/966764/117734034-92236e00-b22d-11eb-8239-26083f3d0163.png)


Note, when pushing this, Husky blocked me on a bunch of lint errors. I bypassed them here, but will push up another PR with a fix for those. 

### What issues does this PR fix or reference?

https://github.com/forcedotcom/soql-tooling/pull/251#discussion_r629080337