### PR TITLE
Jh/additonal null check updates

### DIFF
--- a/packages/soql-builder-ui/package.json
+++ b/packages/soql-builder-ui/package.json
@@ -1,18 +1,11 @@
 {
   "name": "@salesforce/soql-builder-ui",
   "description": "SOQL Builder UI with LWC",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "author": "Salesforce",
   "publishConfig": {
     "access": "public",
-    "registry": "http://registry.npmjs.org/"
-  },
-  "//dependencies": {
-    "comments": "since these are all webpacked, they are moved to devDependencies",
-    "@salesforce/soql-model": "0.1.22",
-    "debounce": "^1.2.0",
-    "immutable": "3.8.2",
-    "rxjs": "^6.6.2"
+    "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
     "@lwc/eslint-plugin-lwc": "^0.12.2",

--- a/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
+++ b/packages/soql-builder-ui/src/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
@@ -330,6 +330,30 @@ describe('WhereModifierGroup should', () => {
     expect(resultingCriteria).toEqual({ type: 'STRING', value: "'WORLD'" });
   });
 
+  it('normalize criteria input for strings, null value', () => {
+    modifierGroup.condition = {
+      field: { fieldName: 'foo' },
+      operator: '=',
+      compareValue: { type: 'STRING', value: 'null' }
+    };
+    modifierGroup.sobjectMetadata = {
+      fields: [{ name: 'foo', type: 'string' }]
+    };
+    let resultingCriteria;
+    const handler = (e) => {
+      resultingCriteria = e.detail.condition.compareValue;
+    };
+    modifierGroup.addEventListener('modifiergroupselection', handler);
+
+    document.body.appendChild(modifierGroup);
+
+    const { criteriaInputEl } = getModifierElements();
+    criteriaInputEl.value = 'null';
+    criteriaInputEl.dispatchEvent(new Event('input'));
+
+    expect(resultingCriteria).toEqual({ type: 'NULL', value: 'null' });
+  });
+
   it('normalize criteria input for non-strings', () => {
     modifierGroup.condition = {
       field: { fieldName: 'foo' },
@@ -539,6 +563,30 @@ describe('WhereModifierGroup should', () => {
         );
         expect(operatorContainerEl.className).not.toContain('error');
       });
+  });
+
+  it('allow user to filter by null with SObject type String', async () => {
+    modifierGroup.condition = {
+      field: { fieldName: 'NamespacePrefix' },
+      operator: '=',
+      compareValue: { type: 'STRING', value: 'null' }
+    };
+    modifierGroup.sobjectMetadata = {
+      fields: [{ name: 'NamespacePrefix', type: 'string' }]
+    };
+    const handler = jest.fn();
+    modifierGroup.addEventListener('modifiergroupselection', handler);
+    document.body.appendChild(modifierGroup);
+    const { criteriaInputEl } = getModifierElements();
+    criteriaInputEl.value = 'null';
+    criteriaInputEl.dispatchEvent(new Event('input'));
+    expect(handler).toHaveBeenCalled();
+    return Promise.resolve().then(() => {
+      const operatorContainerEl = modifierGroup.shadowRoot.querySelector(
+        '[data-el-where-criteria]'
+      );
+      expect(operatorContainerEl.className).not.toContain('error');
+    });
   });
 
   describe('LIKE CONDITIONS', () => {

--- a/packages/soql-common/package.json
+++ b/packages/soql-common/package.json
@@ -31,7 +31,7 @@
   "author": "Salesforce",
   "publishConfig": {
     "access": "public",
-    "registry": "http://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/"
   },
   "license": "BSD-3-Clause"
 }

--- a/packages/soql-data-view/package.json
+++ b/packages/soql-data-view/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@salesforce/soql-data-view",
   "version": "0.1.0",
-  "description": "This is the web assests for viewing SOQL Results",
+  "description": "This is the web assets for viewing SOQL Results",
   "main": "web/",
   "publishConfig": {
     "access": "public",
-    "registry": "http://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
     "test": "echo done"

--- a/packages/soql-model/package.json
+++ b/packages/soql-model/package.json
@@ -34,7 +34,7 @@
   "author": "Salesforce",
   "publishConfig": {
     "access": "public",
-    "registry": "http://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/"
   },
   "license": "BSD-3-Clause"
 }

--- a/packages/soql-model/src/validators/stringValidator.test.ts
+++ b/packages/soql-model/src/validators/stringValidator.test.ts
@@ -19,8 +19,9 @@ describe('StringValidator should', () => {
   });
 
   it('return valid result when user input is NULL or null', () => {
-    expect(validator.validate("'null'")).toEqual(validResult);
-    expect(validator.validate("'NULL'")).toEqual(validResult);
+    // input of 'null' is not normalized to " 'null' " like other strings
+    expect(validator.validate('null')).toEqual(validResult);
+    expect(validator.validate('NULL')).toEqual(validResult);
   });
 
   it('return not valid result for non-string value', () => {


### PR DESCRIPTION
### What does this PR do?
1. Adds some LWC tests to check for errors when filtering by 'null'
2. Updates the StringValidator test
3. Updates the deps in `soql-builder-ui` to match the latest published version
4. Updates the NMP registry to use TLS as required since 10/4/21

